### PR TITLE
Implement authentication service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -416,3 +416,4 @@ FodyWeavers.xsd
 *.msix
 *.msm
 *.msp
+coverage-report/

--- a/Common.Tests/BDD/auth-token-acquisition/auth-token-acquisition.feature
+++ b/Common.Tests/BDD/auth-token-acquisition/auth-token-acquisition.feature
@@ -1,0 +1,13 @@
+Feature: Auth Token Acquisition
+  In order to interact with TAS APIs
+  As a client
+  I want to obtain a bearer token from username and password
+
+  Scenario Outline: Acquire bearer token
+    Given the auth endpoint returns <access_token> and <refresh_token>
+    When I request a token using <username> and <password>
+    Then the AuthenticationService returns <access_token> and <refresh_token>
+
+    Examples:
+      | username | password | access_token | refresh_token |
+      | user1    | pass1    | abc          | xyz           |

--- a/Common.UnitTests/AuthenticationServiceTests.cs
+++ b/Common.UnitTests/AuthenticationServiceTests.cs
@@ -1,0 +1,30 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Moq.Protected;
+
+namespace Common.UnitTests;
+
+public class AuthenticationServiceTests
+{
+    [Fact]
+    public async Task GetBearerTokenAsync_ReturnsToken()
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"access_token\":\"abc\",\"refresh_token\":\"xyz\"}")
+            });
+        var client = new HttpClient(handler.Object);
+        var service = new AuthenticationService(client, "http://localhost/token");
+
+        var token = await service.GetBearerTokenAsync("user", "pass");
+
+        Assert.Equal("abc", token.AccessToken);
+        Assert.Equal("xyz", token.RefreshToken);
+    }
+}

--- a/Common/AuthenticationService.cs
+++ b/Common/AuthenticationService.cs
@@ -1,0 +1,29 @@
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace Common;
+
+public class AuthenticationService
+{
+    private readonly HttpClient _client;
+    private readonly string _authEndpoint;
+
+    public AuthenticationService(HttpClient client, string authEndpoint)
+    {
+        _client = client;
+        _authEndpoint = authEndpoint;
+    }
+
+    /// TASK: Acquire bearer token from TAS
+    public async Task<TokenModel> GetBearerTokenAsync(string username, string password)
+    {
+        var content = new StringContent($"{{\"username\":\"{username}\",\"password\":\"{password}\"}}", Encoding.UTF8, "application/json");
+        var response = await _client.PostAsync(_authEndpoint, content);
+        response.EnsureSuccessStatusCode();
+        var json = await response.Content.ReadAsStringAsync();
+        var model = JsonSerializer.Deserialize<TokenModel>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        return model ?? new TokenModel();
+    }
+}

--- a/Common/TasClient.cs
+++ b/Common/TasClient.cs
@@ -1,0 +1,15 @@
+namespace Common;
+
+public class TasClient
+{
+    private readonly AuthenticationService _authService;
+
+    public TasClient(AuthenticationService authService)
+    {
+        _authService = authService;
+    }
+
+    /// TASK: Authenticate via AuthenticationService
+    public Task<TokenModel> AuthenticateAsync(string username, string password)
+        => _authService.GetBearerTokenAsync(username, password);
+}

--- a/Common/TokenModel.cs
+++ b/Common/TokenModel.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace Common;
+
+public class TokenModel
+{
+    [JsonPropertyName("access_token")]
+    public string AccessToken { get; set; } = string.Empty;
+
+    [JsonPropertyName("refresh_token")]
+    public string RefreshToken { get; set; } = string.Empty;
+}

--- a/docs/goals/dotnet-tas-client-sdk.md
+++ b/docs/goals/dotnet-tas-client-sdk.md
@@ -8,10 +8,10 @@ Status Table (auto-updated)
 
 - [ ] **Feature 1: Authentication & Token Management**
     - [ ] **Story 1.1: Auth Token Acquisition (`auth-token-acquisition.feature`)**
-        - [ ] Add BDD file `Common.Tests/BDD/auth-token-acquisition/auth-token-acquisition.feature`.
-        - [ ] Implement `AuthenticationService.cs` → `GetBearerTokenAsync(string username, string password)`.
-        - [ ] Create `TokenModel.cs` for raw-JSON deserialization.
-        - [ ] Wire `AuthenticationService` into `TasClient.cs` constructor.
+        - [x] Add BDD file `Common.Tests/BDD/auth-token-acquisition/auth-token-acquisition.feature`.
+        - [x] Implement `AuthenticationService.cs` → `GetBearerTokenAsync(string username, string password)`.
+        - [x] Create `TokenModel.cs` for raw-JSON deserialization.
+        - [x] Wire `AuthenticationService` into `TasClient.cs` constructor.
     - [ ] **Story 1.2: Token Refresh Handling (`token-refresh.feature`)**
         - [ ] Add BDD file `Common.Tests/BDD/token-refresh/token-refresh.feature`.
         - [ ] Implement `ITokenRefresher.cs` → `RefreshAsync(string refreshToken)`.


### PR DESCRIPTION
## Summary
- add BDD feature for auth token acquisition
- implement `AuthenticationService` with `GetBearerTokenAsync`
- create `TokenModel` and `TasClient`
- test token retrieval
- mark tasks for auth token acquisition as complete

## Testing
- `dotnet test -tl:off`
- `dotnet test /p:CollectCoverage=true`

------
https://chatgpt.com/codex/tasks/task_e_68619cf129c08330bfb6d0bdb43459b1