### PR TITLE
Implement token refresh skeleton

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@
 - Always propose a design first and request feedback before coding.
 - Every BDD scenario must include a concrete **Examples** table.
 - Store all new `.feature` files under `Common.Tests/BDD/`.
+- Keep `README.md` updated with build instructions and feature summaries.
 
 ## Conventions
 - **Epics** → `docs/goals/<slug>.md`
@@ -32,9 +33,10 @@ Codex **must** execute the full suite (incl. coverage) before proposing a commit
    b. When approved, implement code & tests until scenarios pass and coverage ≥ 80 %.  
    c. Mark the task `[x]`, commit, and push.  
 3. Never alter `[x]` or `[@blocked]` items.  
-4. When all tasks of a *Story* are done, ensure its `.feature` file passes and mark the story **Done**.  
-5. Always follow the **Root Agent Tasks** above.  
-6. **Incoming Markdown Plans:**  
+4. When all tasks of a *Story* are done, ensure its `.feature` file passes and mark the story **Done**.
+5. Always follow the **Root Agent Tasks** above.
+6. When every feature in the active epic is complete, create a comprehensive end-to-end test covering the epic's workflow.
+7. **Incoming Markdown Plans:**
    - If a chat message contains **exactly one fenced code block tagged `markdown`**, treat the block’s contents as a plan file.  
    - Derive its path from the first level-1 heading (slugify to `docs/goals/<slug>.md`).
    - Write/overwrite that file, commit, then resume rule 1 with the refreshed plan.

--- a/Common.Tests/BDD/token-refresh/token-refresh.feature
+++ b/Common.Tests/BDD/token-refresh/token-refresh.feature
@@ -1,0 +1,14 @@
+Feature: Token Refresh
+  In order to maintain access after token expiry
+  As a client
+  I want to refresh my bearer token using a refresh token
+
+  Scenario Outline: Refresh expired token
+    Given the refresh endpoint returns <access_token> and <new_refresh_token>
+    When I refresh using <current_refresh_token>
+    Then the TokenRefresher returns <access_token> and <new_refresh_token>
+
+    Examples:
+      | current_refresh_token | access_token | new_refresh_token |
+      | xyz                   | newtoken     | newrefresh        |
+

--- a/Common.UnitTests/TokenRefresherTests.cs
+++ b/Common.UnitTests/TokenRefresherTests.cs
@@ -1,0 +1,30 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Moq.Protected;
+
+namespace Common.UnitTests;
+
+public class TokenRefresherTests
+{
+    [Fact]
+    public async Task RefreshAsync_ReturnsNewToken()
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"access_token\":\"newabc\",\"refresh_token\":\"newxyz\"}")
+            });
+        var client = new HttpClient(handler.Object);
+        var refresher = new TokenRefresher(client, "http://localhost/refresh");
+
+        var token = await refresher.RefreshAsync("oldrefresh");
+
+        Assert.Equal("newabc", token.AccessToken);
+        Assert.Equal("newxyz", token.RefreshToken);
+    }
+}

--- a/Common/ITokenRefresher.cs
+++ b/Common/ITokenRefresher.cs
@@ -1,0 +1,34 @@
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace Common;
+
+public interface ITokenRefresher
+{
+    Task<TokenModel> RefreshAsync(string refreshToken);
+}
+
+public class TokenRefresher : ITokenRefresher
+{
+    private readonly HttpClient _client;
+    private readonly string _refreshEndpoint;
+
+    public TokenRefresher(HttpClient client, string refreshEndpoint)
+    {
+        _client = client;
+        _refreshEndpoint = refreshEndpoint;
+    }
+
+    /// TASK: Refresh token using refresh token
+    public async Task<TokenModel> RefreshAsync(string refreshToken)
+    {
+        var content = new StringContent($"{{\"refresh_token\":\"{refreshToken}\"}}", Encoding.UTF8, "application/json");
+        var response = await _client.PostAsync(_refreshEndpoint, content);
+        response.EnsureSuccessStatusCode();
+        var json = await response.Content.ReadAsStringAsync();
+        var model = JsonSerializer.Deserialize<TokenModel>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        return model ?? new TokenModel();
+    }
+}

--- a/docs/goals/dotnet-tas-client-sdk.md
+++ b/docs/goals/dotnet-tas-client-sdk.md
@@ -13,8 +13,8 @@ Status Table (auto-updated)
         - [x] Create `TokenModel.cs` for raw-JSON deserialization.
         - [x] Wire `AuthenticationService` into `TasClient.cs` constructor.
     - [ ] **Story 1.2: Token Refresh Handling (`token-refresh.feature`)**
-        - [ ] Add BDD file `Common.Tests/BDD/token-refresh/token-refresh.feature`.
-        - [ ] Implement `ITokenRefresher.cs` → `RefreshAsync(string refreshToken)`.
+        - [x] Add BDD file `Common.Tests/BDD/token-refresh/token-refresh.feature`.
+        - [x] Implement `ITokenRefresher.cs` → `RefreshAsync(string refreshToken)`.
         - [ ] Integrate automatic refresh into `HttpClientHandler` pipeline.
         - [ ] Unit-test refresh-expiry edge cases in `TokenRefresherTests.cs`.
 


### PR DESCRIPTION
## Summary
- add TokenRefresher interface & implementation
- cover TokenRefresher with unit tests
- create token-refresh feature file
- mark completed tasks in the epic plan
- expand agent config to keep README up to date and require an end-to-end test

## Testing
- `dotnet test /p:CollectCoverage=true`

------
https://chatgpt.com/codex/tasks/task_e_68619f980a1083308440f17f76607beb