### PR TITLE
Implement token refresh handler

### DIFF
--- a/Common.UnitTests/TokenRefreshingHandlerTests.cs
+++ b/Common.UnitTests/TokenRefreshingHandlerTests.cs
@@ -1,0 +1,33 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Moq.Protected;
+
+namespace Common.UnitTests;
+
+public class TokenRefreshingHandlerTests
+{
+    [Fact]
+    public async Task SendsRefreshRequestOnUnauthorized()
+    {
+        var refresher = new Mock<ITokenRefresher>();
+        refresher.Setup(r => r.RefreshAsync("r1"))
+            .ReturnsAsync(new TokenModel { AccessToken = "new", RefreshToken = "r2" });
+
+        var innerHandler = new Mock<HttpMessageHandler>();
+        innerHandler.Protected()
+            .SetupSequence<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.Unauthorized))
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+
+        var handler = new TokenRefreshingHandler(refresher.Object, new TokenModel { AccessToken = "old", RefreshToken = "r1" }, innerHandler.Object);
+        var client = new HttpClient(handler);
+
+        var resp = await client.GetAsync("http://example.com");
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        refresher.Verify(r => r.RefreshAsync("r1"), Times.Once);
+    }
+}

--- a/Common/TokenRefreshingHandler.cs
+++ b/Common/TokenRefreshingHandler.cs
@@ -1,0 +1,32 @@
+using System.Net;
+using System.Net.Http.Headers;
+
+namespace Common;
+
+public class TokenRefreshingHandler : DelegatingHandler
+{
+    private readonly ITokenRefresher _refresher;
+    private TokenModel _token;
+
+    public TokenRefreshingHandler(ITokenRefresher refresher, TokenModel token, HttpMessageHandler? innerHandler = null)
+    {
+        _refresher = refresher;
+        _token = token;
+        InnerHandler = innerHandler ?? new HttpClientHandler();
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token.AccessToken);
+
+        var response = await base.SendAsync(request, cancellationToken);
+        if (response.StatusCode == HttpStatusCode.Unauthorized)
+        {
+            response.Dispose();
+            _token = await _refresher.RefreshAsync(_token.RefreshToken);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token.AccessToken);
+            response = await base.SendAsync(request, cancellationToken);
+        }
+        return response;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Common Solution
 
-This repository contains a basic .NET solution with a library, an example application and unit tests.
+This repository contains a basic .NET solution with a library, an example application and unit tests. The library now includes a HTTP message handler that automatically refreshes expired bearer tokens.
 
 ## Projects
 - **Common** - reusable library code.

--- a/docs/goals/dotnet-tas-client-sdk.md
+++ b/docs/goals/dotnet-tas-client-sdk.md
@@ -15,7 +15,7 @@ Status Table (auto-updated)
     - [ ] **Story 1.2: Token Refresh Handling (`token-refresh.feature`)**
         - [x] Add BDD file `Common.Tests/BDD/token-refresh/token-refresh.feature`.
         - [x] Implement `ITokenRefresher.cs` → `RefreshAsync(string refreshToken)`.
-        - [ ] Integrate automatic refresh into `HttpClientHandler` pipeline.
+        - [x] Integrate automatic refresh into `HttpClientHandler` pipeline.
         - [ ] Unit-test refresh-expiry edge cases in `TokenRefresherTests.cs`.
 
 - [ ] **Feature 2: Client Initialization & Configuration**


### PR DESCRIPTION
## Summary
- implement `TokenRefreshingHandler` delegating handler to auto-refresh tokens
- add unit tests for refresh behavior
- update epic plan to mark refresh handler step complete
- document handler in README

## Testing
- `dotnet test`
- `dotnet test /p:CollectCoverage=true`


------
https://chatgpt.com/codex/tasks/task_e_6861a28846f88330af54aa9e232a9830