### PR TITLE
Add refresh expiry test

### DIFF
--- a/Common.UnitTests/TokenRefresherTests.cs
+++ b/Common.UnitTests/TokenRefresherTests.cs
@@ -31,4 +31,21 @@ public class TokenRefresherTests
         Assert.Equal("newabc", token.AccessToken);
         Assert.Equal("newxyz", token.RefreshToken);
     }
+
+    [Fact]
+    public async Task RefreshAsync_ThrowsWhenUnauthorized()
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.Unauthorized));
+
+        var services = new ServiceCollection();
+        services.AddSingleton<ITokenRefresher>(_ =>
+            new TokenRefresher(new HttpClient(handler.Object), "http://localhost/refresh"));
+        var provider = services.BuildServiceProvider();
+        var refresher = provider.GetRequiredService<ITokenRefresher>();
+
+        await Assert.ThrowsAsync<HttpRequestException>(() => refresher.RefreshAsync("badrefresh"));
+    }
 }

--- a/docs/goals/dotnet-tas-client-sdk.md
+++ b/docs/goals/dotnet-tas-client-sdk.md
@@ -16,7 +16,7 @@ Status Table (auto-updated)
         - [x] Add BDD file `Common.Tests/BDD/token-refresh/token-refresh.feature`.
         - [x] Implement `ITokenRefresher.cs` → `RefreshAsync(string refreshToken)`.
         - [x] Integrate automatic refresh into `HttpClientHandler` pipeline.
-        - [ ] Unit-test refresh-expiry edge cases in `TokenRefresherTests.cs`.
+        - [x] Unit-test refresh-expiry edge cases in `TokenRefresherTests.cs`.
 
 - [ ] **Feature 2: Client Initialization & Configuration**
     - [ ] **Story 2.1: Initialize Client (`client-initialization.feature`)**
@@ -58,3 +58,7 @@ References
 - Authentication & enterprise SSO in TAS for VMs  <https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/4-0/tpcf/auth-sso.html>  
 - What’s new in .NET 9 – SDK & runtime overview  <https://learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-9/overview>  
 - Official .NET 9 download page  <https://dotnet.microsoft.com/en-us/download/dotnet/9.0>
+
+## Codex Tasks
+- [ ] Add BDD file `Common.Tests/BDD/client-initialization/client-initialization.feature`
+- [ ] Start next task after merge


### PR DESCRIPTION
## Summary
- cover unauthorized case in `RefreshAsync`
- mark refresh expiry edge case task done in the epic plan
- add next step codex tasks to the plan

## Testing
- `dotnet test --no-build -tl:off`
- `dotnet test /p:CollectCoverage=true -tl:off --results-directory ./TestResults`


------
https://chatgpt.com/codex/tasks/task_e_6861a6415380833093b11550f85d2cb0