### PR TITLE
Add client initialization BDD and update agent config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,16 +31,17 @@
 Codex **must** execute the full suite (incl. coverage) before proposing a commit.
 
 ## Autonomous-Agent Rules
-1. Work through unchecked `[ ]` tasks in order (`@parallel` tasks may run concurrently).  
-2. For each task  
+1. Work through unchecked `[ ]` tasks in order (`@parallel` tasks may run concurrently).
+2. Focus each run on a single story. Reference the active plan in `docs/goals/*.md` to confirm its tasks and validate at run end that they were implemented.
+3. For each task
    a. Draft a design (class / API sketch) and request human approval.  
    b. When approved, implement code & tests until scenarios pass and coverage ≥ 80 %.  
    c. Mark the task `[x]`, commit, and push.  
-3. Never alter `[x]` or `[@blocked]` items.  
-4. When all tasks of a *Story* are done, ensure its `.feature` file passes and mark the story **Done**.
-5. Always follow the **Root Agent Tasks** above.
-6. When every feature in the active epic is complete, create a comprehensive end-to-end test covering the epic's workflow.
-7. **Incoming Markdown Plans:**
+4. Never alter `[x]` or `[@blocked]` items.
+5. When all tasks of a *Story* are done, ensure its `.feature` file passes and mark the story **Done**.
+6. Always follow the **Root Agent Tasks** above.
+7. When every feature in the active epic is complete, create a comprehensive end-to-end test covering the epic's workflow.
+8. **Incoming Markdown Plans:**
    - If a chat message contains **exactly one fenced code block tagged `markdown`**, treat the block’s contents as a plan file.  
    - Derive its path from the first level-1 heading (slugify to `docs/goals/<slug>.md`).
    - Write/overwrite that file, commit, then resume rule 1 with the refreshed plan.
@@ -51,6 +52,8 @@ Codex **must** execute the full suite (incl. coverage) before proposing a commit
      the following PR has a clear entry point.
    - When generating or updating any plan, include a final `## Codex Tasks`
      section so these tasks can be executed from the Codex interface.
+
+9. If a user message is exactly `plan`, produce a concise plan for the current story using tasks from `docs/goals/*.md`. Output it in a fenced `markdown` block with a `## Codex Tasks` list, then continue with rule 1.
 
 ## Project Plan Lookup
 Find the active epic’s plan under `docs/goals/*.md` and follow its Feature → Story → Task hierarchy.

--- a/Common.Tests/BDD/client-initialization/client-initialization.feature
+++ b/Common.Tests/BDD/client-initialization/client-initialization.feature
@@ -1,0 +1,13 @@
+Feature: Client Initialization
+  In order to communicate with a TAS foundation
+  As a developer
+  I want to create a TasClient from configured credentials
+
+  Scenario Outline: Initialize TasClient with valid options
+    Given I configure TasClient with foundation URI <uri>, username <username>, password <password>
+    When I build the TasClient
+    Then the client is initialized successfully
+
+    Examples:
+      | uri             | username | password |
+      | https://api.tas | user     | pass     |

--- a/docs/goals/dotnet-tas-client-sdk.md
+++ b/docs/goals/dotnet-tas-client-sdk.md
@@ -20,7 +20,7 @@ Status Table (auto-updated)
 
 - [ ] **Feature 2: Client Initialization & Configuration**
     - [ ] **Story 2.1: Initialize Client (`client-initialization.feature`)**
-        - [ ] Add BDD file `Common.Tests/BDD/client-initialization/client-initialization.feature`.
+        - [x] Add BDD file `Common.Tests/BDD/client-initialization/client-initialization.feature`.
         - [ ] Implement `TasClientOptions.cs` (foundation URI, username, password).
         - [ ] Build `TasClientBuilder.cs` fluent builder for options validation.
         - [ ] Register `TasClient` + dependencies in DI (`ServiceCollectionExtensions.cs`).
@@ -60,5 +60,5 @@ References
 - Official .NET 9 download page  <https://dotnet.microsoft.com/en-us/download/dotnet/9.0>
 
 ## Codex Tasks
-- [ ] Add BDD file `Common.Tests/BDD/client-initialization/client-initialization.feature`
+- [x] Add BDD file `Common.Tests/BDD/client-initialization/client-initialization.feature`
 - [ ] Start next task after merge


### PR DESCRIPTION
## Summary
- add `client-initialization.feature` to start the Client Initialization story
- mark the feature file task as complete in the active plan
- update `AGENTS.md` so each run focuses on a story and `plan` triggers plan generation

## Testing
- `dotnet build -tl:off`
- `dotnet test -tl:off`
- `dotnet test /p:CollectCoverage=true`


------
https://chatgpt.com/codex/tasks/task_e_6861a87c8ef88330b24112e417f9554e