### PR TITLE
Implement client initialization

### DIFF
--- a/Common.UnitTests/ServiceCollectionExtensionsTests.cs
+++ b/Common.UnitTests/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,22 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Common.UnitTests;
+
+public class ServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddTasClient_RegistersClient()
+    {
+        var services = new ServiceCollection();
+        services.AddTasClient(b => b
+            .WithFoundationUri("https://api.tas")
+            .WithCredentials("user","pass"));
+        var provider = services.BuildServiceProvider();
+
+        var client = provider.GetRequiredService<ITasClient>();
+        var auth = provider.GetRequiredService<IAuthenticationService>();
+
+        Assert.NotNull(client);
+        Assert.NotNull(auth);
+    }
+}

--- a/Common.UnitTests/TasClientBuilderTests.cs
+++ b/Common.UnitTests/TasClientBuilderTests.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Common.UnitTests;
+
+public class TasClientBuilderTests
+{
+    [Fact]
+    public void Build_ReturnsClient()
+    {
+        var builder = new TasClientBuilder()
+            .WithFoundationUri("https://api.tas")
+            .WithCredentials("user","pass");
+
+        var client = builder.Build();
+
+        Assert.NotNull(client);
+    }
+
+    [Fact]
+    public void Build_ThrowsWithoutUsername()
+    {
+        var builder = new TasClientBuilder()
+            .WithFoundationUri("https://api.tas");
+
+        Assert.Throws<InvalidOperationException>(() => builder.Build());
+    }
+}

--- a/Common/Common.csproj
+++ b/Common/Common.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/Common/ServiceCollectionExtensions.cs
+++ b/Common/ServiceCollectionExtensions.cs
@@ -1,0 +1,19 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Common;
+
+public static class ServiceCollectionExtensions
+{
+    /// TASK: Add TasClient and dependencies to the service collection
+    public static IServiceCollection AddTasClient(this IServiceCollection services, Action<TasClientBuilder> configure)
+    {
+        var builder = new TasClientBuilder();
+        configure(builder);
+        var client = builder.Build();
+
+        services.AddSingleton(builder.Options);
+        services.AddSingleton(builder.AuthenticationService!);
+        services.AddSingleton<ITasClient>(client);
+        return services;
+    }
+}

--- a/Common/TasClientBuilder.cs
+++ b/Common/TasClientBuilder.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Net.Http;
+
+namespace Common;
+
+public class TasClientBuilder
+{
+    private readonly TasClientOptions _options = new();
+    public TasClientOptions Options => _options;
+    public IAuthenticationService? AuthenticationService { get; private set; }
+
+    public TasClientBuilder WithFoundationUri(string uri)
+    {
+        _options.FoundationUri = new Uri(uri);
+        return this;
+    }
+
+    public TasClientBuilder WithCredentials(string username, string password)
+    {
+        _options.Username = username;
+        _options.Password = password;
+        return this;
+    }
+
+    /// TASK: Build TasClient using provided options
+    public TasClient Build()
+    {
+        _options.Validate();
+        AuthenticationService = new AuthenticationService(new HttpClient(), $"{_options.FoundationUri}/oauth/token");
+        return new TasClient(AuthenticationService);
+    }
+}

--- a/Common/TasClientOptions.cs
+++ b/Common/TasClientOptions.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Common;
+
+public class TasClientOptions
+{
+    public Uri FoundationUri { get; set; } = new("https://localhost");
+    public string Username { get; set; } = string.Empty;
+    public string Password { get; set; } = string.Empty;
+
+    /// TASK: Validate required fields
+    public void Validate()
+    {
+        if (FoundationUri == null)
+            throw new InvalidOperationException("FoundationUri is required");
+        if (string.IsNullOrWhiteSpace(Username))
+            throw new InvalidOperationException("Username is required");
+        if (string.IsNullOrWhiteSpace(Password))
+            throw new InvalidOperationException("Password is required");
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Common Solution
 
 This repository contains a basic .NET solution with a library, an example application and unit tests. The library now includes a HTTP message handler that automatically refreshes expired bearer tokens.
+It also supports initializing a `TasClient` using `TasClientBuilder` and registering it in dependency injection.
 
 ## Projects
 - **Common** - reusable library code.


### PR DESCRIPTION
## Summary
- add `TasClientOptions` for configuration
- implement `TasClientBuilder` for fluent setup & validation
- register the client in DI using `ServiceCollectionExtensions`
- unit test builder and DI registration
- document the new initialization capability in the README

## Testing
- `dotnet build -tl:off`
- `dotnet test -tl:off`
- `dotnet test /p:CollectCoverage=true -tl:off`

------
https://chatgpt.com/codex/tasks/task_e_6861aa1b83e4833084c9d896fbec79ea