### PR TITLE
Implement Story 4.1: app retrieval

### DIFF
--- a/Common.Test/AppApiIntegrationTests.cs
+++ b/Common.Test/AppApiIntegrationTests.cs
@@ -1,0 +1,48 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Common.Test;
+
+public class AppApiIntegrationTests
+{
+    [Fact]
+    public async Task GetAppsAsync_ReturnsJson()
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"apps\":\"a\"}")
+            });
+        var services = new ServiceCollection();
+        services.AddSingleton<IAppApi>(_ => new AppApi(new HttpClient(handler.Object), "http://localhost"));
+        var provider = services.BuildServiceProvider();
+        var api = provider.GetRequiredService<IAppApi>();
+
+        var json = await api.GetAppsAsync("space1");
+
+        Assert.Equal("{\"apps\":\"a\"}", json);
+    }
+
+    [Fact]
+    public async Task GetAppsAsync_ThrowsOnNotFound()
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.NotFound));
+        var services = new ServiceCollection();
+        services.AddSingleton<IAppApi>(_ => new AppApi(new HttpClient(handler.Object), "http://localhost"));
+        var provider = services.BuildServiceProvider();
+        var api = provider.GetRequiredService<IAppApi>();
+
+        await Assert.ThrowsAsync<HttpRequestException>(() => api.GetAppsAsync("space1"));
+    }
+}

--- a/Common.Test/TasClientIntegrationTests.cs
+++ b/Common.Test/TasClientIntegrationTests.cs
@@ -27,6 +27,7 @@ public class TasClientIntegrationTests
         services.AddSingleton<IFoundationApi>(_ =>
             new FoundationApi(new HttpClient(new Mock<HttpMessageHandler>().Object), "http://localhost/info"));
         services.AddSingleton<IOrgSpaceApi>(new Mock<IOrgSpaceApi>().Object);
+        services.AddSingleton<IAppApi>(new Mock<IAppApi>().Object);
         services.AddSingleton<ITasClient, TasClient>();
         var provider = services.BuildServiceProvider();
         var client = provider.GetRequiredService<ITasClient>();
@@ -59,11 +60,13 @@ public class TasClientIntegrationTests
         var options = provider.GetRequiredService<TasClientOptions>();
         var api = provider.GetRequiredService<IFoundationApi>();
         var orgApi = provider.GetRequiredService<IOrgSpaceApi>();
+        var appApi = provider.GetRequiredService<IAppApi>();
 
         Assert.NotNull(client);
         Assert.Equal("https://api.tas/", options.FoundationUri.ToString());
         Assert.NotNull(api);
         Assert.NotNull(orgApi);
+        Assert.NotNull(appApi);
     }
 
     [Fact]
@@ -103,6 +106,7 @@ public class TasClientIntegrationTests
         services.AddSingleton<IAuthenticationService>(new Mock<IAuthenticationService>().Object);
         services.AddSingleton<IFoundationApi>(_ => new FoundationApi(new HttpClient(apiHandler.Object), "http://localhost/info"));
         services.AddSingleton<IOrgSpaceApi>(new Mock<IOrgSpaceApi>().Object);
+        services.AddSingleton<IAppApi>(new Mock<IAppApi>().Object);
         services.AddSingleton<ITasClient, TasClient>();
         var provider = services.BuildServiceProvider();
         var client = provider.GetRequiredService<ITasClient>();
@@ -129,6 +133,7 @@ public class TasClientIntegrationTests
         services.AddSingleton<IAuthenticationService>(new Mock<IAuthenticationService>().Object);
         services.AddSingleton<IFoundationApi>(new Mock<IFoundationApi>().Object);
         services.AddSingleton<IOrgSpaceApi>(_ => new OrgSpaceApi(new HttpClient(handler.Object), "http://localhost"));
+        services.AddSingleton<IAppApi>(new Mock<IAppApi>().Object);
         services.AddSingleton<ITasClient, TasClient>();
         var provider = services.BuildServiceProvider();
         var client = provider.GetRequiredService<ITasClient>();

--- a/Common.Tests/BDD/app-component-info/AppComponentInfoSteps.cs
+++ b/Common.Tests/BDD/app-component-info/AppComponentInfoSteps.cs
@@ -1,0 +1,56 @@
+using System.Net;
+using System.Net.Http;
+using Xunit;
+
+namespace Common.Tests.BDD.AppComponentInfo;
+
+public class AppComponentInfoSteps
+{
+    private AppApi? _api;
+    private string? _json;
+
+    [Given("the app endpoint returns {json}")]
+    public void GivenEndpoint(string json)
+    {
+        _api = new AppApi(new HttpClient(new JsonHandler(json)), "http://localhost");
+    }
+
+    [When("I request apps for space {spaceId}")]
+    public async Task WhenIRequest(string spaceId)
+    {
+        if (_api != null)
+            _json = await _api.GetAppsAsync(spaceId);
+    }
+
+    [Then("the app API returns {json}")]
+    public void ThenReturns(string json)
+    {
+        Assert.Equal(json, _json);
+    }
+}
+
+public class JsonHandler : HttpMessageHandler
+{
+    private readonly string _json;
+    public JsonHandler(string json) => _json = json;
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(_json) });
+}
+
+[AttributeUsage(AttributeTargets.Method)]
+public sealed class GivenAttribute : Attribute
+{
+    public GivenAttribute(string text) { }
+}
+
+[AttributeUsage(AttributeTargets.Method)]
+public sealed class WhenAttribute : Attribute
+{
+    public WhenAttribute(string text) { }
+}
+
+[AttributeUsage(AttributeTargets.Method)]
+public sealed class ThenAttribute : Attribute
+{
+    public ThenAttribute(string text) { }
+}

--- a/Common.Tests/BDD/app-component-info/app-component-info.feature
+++ b/Common.Tests/BDD/app-component-info/app-component-info.feature
@@ -1,0 +1,13 @@
+Feature: App Component Info
+  In order to inspect applications
+  As a client
+  I want to retrieve apps for a space as raw JSON
+
+  Scenario Outline: Retrieve apps
+    Given the app endpoint returns <json>
+    When I request apps for space <spaceId>
+    Then the app API returns <json>
+
+    Examples:
+      | spaceId | json           |
+      | space1  | {"apps":"a"} |

--- a/Common/IAppApi.cs
+++ b/Common/IAppApi.cs
@@ -1,0 +1,28 @@
+using System.Net.Http;
+
+namespace Common;
+
+public interface IAppApi
+{
+    Task<string> GetAppsAsync(string spaceId);
+}
+
+public class AppApi : IAppApi
+{
+    private readonly HttpClient _client;
+    private readonly string _baseUri;
+
+    public AppApi(HttpClient client, string baseUri)
+    {
+        _client = client;
+        _baseUri = baseUri.TrimEnd('/');
+    }
+
+    /// TASK: Get apps for a space as raw JSON
+    public async Task<string> GetAppsAsync(string spaceId)
+    {
+        var resp = await _client.GetAsync($"{_baseUri}/v3/spaces/{spaceId}/apps");
+        resp.EnsureSuccessStatusCode();
+        return await resp.Content.ReadAsStringAsync();
+    }
+}

--- a/Common/ITasClient.cs
+++ b/Common/ITasClient.cs
@@ -12,4 +12,7 @@ public interface ITasClient
 
     /// TASK: Retrieve spaces for a specific org as raw JSON
     Task<string> GetSpacesAsync(string orgId);
+
+    /// TASK: Retrieve apps for a specific space as raw JSON
+    Task<string> GetAppsAsync(string spaceId);
 }

--- a/Common/ServiceCollectionExtensions.cs
+++ b/Common/ServiceCollectionExtensions.cs
@@ -15,6 +15,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton(builder.AuthenticationService!);
         services.AddSingleton(builder.FoundationApi!);
         services.AddSingleton(builder.OrgSpaceApi!);
+        services.AddSingleton(builder.AppApi!);
         services.AddSingleton<ITasClient>(client);
         return services;
     }

--- a/Common/TasClient.cs
+++ b/Common/TasClient.cs
@@ -5,12 +5,14 @@ public class TasClient : ITasClient
     private readonly IAuthenticationService _authService;
     private readonly IFoundationApi _foundationApi;
     private readonly IOrgSpaceApi _orgSpaceApi;
+    private readonly IAppApi _appApi;
 
-    public TasClient(IAuthenticationService authService, IFoundationApi foundationApi, IOrgSpaceApi orgSpaceApi)
+    public TasClient(IAuthenticationService authService, IFoundationApi foundationApi, IOrgSpaceApi orgSpaceApi, IAppApi appApi)
     {
         _authService = authService;
         _foundationApi = foundationApi;
         _orgSpaceApi = orgSpaceApi;
+        _appApi = appApi;
     }
 
     /// TASK: Authenticate via AuthenticationService
@@ -28,4 +30,8 @@ public class TasClient : ITasClient
     /// TASK: Delegate to OrgSpaceApi for spaces
     public Task<string> GetSpacesAsync(string orgId)
         => _orgSpaceApi.GetSpacesForOrgAsync(orgId);
+
+    /// TASK: Delegate to AppApi for apps
+    public Task<string> GetAppsAsync(string spaceId)
+        => _appApi.GetAppsAsync(spaceId);
 }

--- a/Common/TasClientBuilder.cs
+++ b/Common/TasClientBuilder.cs
@@ -10,6 +10,7 @@ public class TasClientBuilder
     public IAuthenticationService? AuthenticationService { get; private set; }
     public IFoundationApi? FoundationApi { get; private set; }
     public IOrgSpaceApi? OrgSpaceApi { get; private set; }
+    public IAppApi? AppApi { get; private set; }
 
     public TasClientBuilder WithFoundationUri(string uri)
     {
@@ -31,6 +32,7 @@ public class TasClientBuilder
         AuthenticationService = new AuthenticationService(new HttpClient(), $"{_options.FoundationUri}/oauth/token");
         FoundationApi = new FoundationApi(new HttpClient(), $"{_options.FoundationUri}/v3/info");
         OrgSpaceApi = new OrgSpaceApi(new HttpClient(), _options.FoundationUri.ToString());
-        return new TasClient(AuthenticationService, FoundationApi, OrgSpaceApi);
+        AppApi = new AppApi(new HttpClient(), _options.FoundationUri.ToString());
+        return new TasClient(AuthenticationService, FoundationApi, OrgSpaceApi, AppApi);
     }
 }

--- a/docs/goals/dotnet-tas-client-sdk.md
+++ b/docs/goals/dotnet-tas-client-sdk.md
@@ -39,11 +39,11 @@ Status Table (auto-updated)
         - [x] Add resilience policies for 429/5xx in `OrgSpaceApi.cs`.
 
 - [ ] **Feature 4: Application & Process Retrieval**
-    - [ ] **Story 4.1: Retrieve App / Component Info (`app-component-info.feature`)**
-        - [ ] Add BDD file `Common.Tests/BDD/app-component-info/app-component-info.feature`.
-        - [ ] Implement `AppApi.cs` → `GetAppsAsync(spaceId)` (raw JSON).
-        - [ ] Expose `TasClient.GetAppsAsync(spaceId)`.
-        - [ ] Add integration test `AppApiIntegrationTests.cs` for 200/404.
+    - [x] **Story 4.1: Retrieve App / Component Info (`app-component-info.feature`)**
+        - [x] Add BDD file `Common.Tests/BDD/app-component-info/app-component-info.feature`.
+        - [x] Implement `AppApi.cs` → `GetAppsAsync(spaceId)` (raw JSON).
+        - [x] Expose `TasClient.GetAppsAsync(spaceId)`.
+        - [x] Add integration test `AppApiIntegrationTests.cs` for 200/404.
     - [ ] **Story 4.2: Retrieve Process Info (`process-info.feature`)**
         - [ ] Add BDD file `Common.Tests/BDD/process-info/process-info.feature`.
         - [ ] Implement `ProcessApi.cs` → `GetProcessesAsync(appId)`.
@@ -70,5 +70,8 @@ References
 - [x] Add step definitions for auth and token refresh features
 - [x] Add BDD file `Common.Tests/BDD/org-space-info/org-space-info.feature`
 - [x] Implement OrgSpaceApi and TasClient methods
+- [x] Add BDD file `Common.Tests/BDD/app-component-info/app-component-info.feature`
+- [x] Implement AppApi and TasClient method
+- [x] Add integration test `AppApiIntegrationTests.cs`
 - [ ] Ensure next step is clear for Codex
 - [ ] Start next task after merge


### PR DESCRIPTION
## Summary
- add `app-component-info.feature` and steps
- implement `AppApi` with `GetAppsAsync`
- wire `TasClient` with new `IAppApi` dependency and method
- register `AppApi` via builder and DI extensions
- add integration tests for `AppApi`
- update goals to mark Story 4.1 complete

## Testing
- `dotnet test -tl:off`
- `dotnet test Common.UnitTests/Common.UnitTests.csproj /p:CollectCoverage=true`
- `dotnet test Common.Test/Common.Test.csproj /p:CollectCoverage=true`


------
https://chatgpt.com/codex/tasks/task_e_6861b428a4b88330bcc0452917f9131d