### PR TITLE
Add ProcessApi with tests

### DIFF
--- a/Common.Test/TasClientIntegrationTests.cs
+++ b/Common.Test/TasClientIntegrationTests.cs
@@ -28,6 +28,7 @@ public class TasClientIntegrationTests
             new FoundationApi(new HttpClient(new Mock<HttpMessageHandler>().Object), "http://localhost/info"));
         services.AddSingleton<IOrgSpaceApi>(new Mock<IOrgSpaceApi>().Object);
         services.AddSingleton<IAppApi>(new Mock<IAppApi>().Object);
+        services.AddSingleton<IProcessApi>(new Mock<IProcessApi>().Object);
         services.AddSingleton<ITasClient, TasClient>();
         var provider = services.BuildServiceProvider();
         var client = provider.GetRequiredService<ITasClient>();
@@ -107,6 +108,7 @@ public class TasClientIntegrationTests
         services.AddSingleton<IFoundationApi>(_ => new FoundationApi(new HttpClient(apiHandler.Object), "http://localhost/info"));
         services.AddSingleton<IOrgSpaceApi>(new Mock<IOrgSpaceApi>().Object);
         services.AddSingleton<IAppApi>(new Mock<IAppApi>().Object);
+        services.AddSingleton<IProcessApi>(new Mock<IProcessApi>().Object);
         services.AddSingleton<ITasClient, TasClient>();
         var provider = services.BuildServiceProvider();
         var client = provider.GetRequiredService<ITasClient>();
@@ -134,6 +136,7 @@ public class TasClientIntegrationTests
         services.AddSingleton<IFoundationApi>(new Mock<IFoundationApi>().Object);
         services.AddSingleton<IOrgSpaceApi>(_ => new OrgSpaceApi(new HttpClient(handler.Object), "http://localhost"));
         services.AddSingleton<IAppApi>(new Mock<IAppApi>().Object);
+        services.AddSingleton<IProcessApi>(new Mock<IProcessApi>().Object);
         services.AddSingleton<ITasClient, TasClient>();
         var provider = services.BuildServiceProvider();
         var client = provider.GetRequiredService<ITasClient>();

--- a/Common.Tests/BDD/process-info/ProcessInfoSteps.cs
+++ b/Common.Tests/BDD/process-info/ProcessInfoSteps.cs
@@ -1,0 +1,56 @@
+using System.Net;
+using System.Net.Http;
+using Xunit;
+
+namespace Common.Tests.BDD.ProcessInfo;
+
+public class ProcessInfoSteps
+{
+    private ProcessApi? _api;
+    private string? _json;
+
+    [Given("the process endpoint returns {json}")]
+    public void GivenEndpoint(string json)
+    {
+        _api = new ProcessApi(new HttpClient(new JsonHandler(json)), "http://localhost");
+    }
+
+    [When("I request processes for app {appId}")]
+    public async Task WhenRequest(string appId)
+    {
+        if (_api != null)
+            _json = await _api.GetProcessesAsync(appId);
+    }
+
+    [Then("the process API returns {json}")]
+    public void ThenReturns(string json)
+    {
+        Assert.Equal(json, _json);
+    }
+}
+
+public class JsonHandler : HttpMessageHandler
+{
+    private readonly string _json;
+    public JsonHandler(string json) => _json = json;
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(_json) });
+}
+
+[AttributeUsage(AttributeTargets.Method)]
+public sealed class GivenAttribute : Attribute
+{
+    public GivenAttribute(string text) { }
+}
+
+[AttributeUsage(AttributeTargets.Method)]
+public sealed class WhenAttribute : Attribute
+{
+    public WhenAttribute(string text) { }
+}
+
+[AttributeUsage(AttributeTargets.Method)]
+public sealed class ThenAttribute : Attribute
+{
+    public ThenAttribute(string text) { }
+}

--- a/Common.Tests/BDD/process-info/process-info.feature
+++ b/Common.Tests/BDD/process-info/process-info.feature
@@ -1,0 +1,13 @@
+Feature: Process Info
+  In order to monitor application processes
+  As a client
+  I want to retrieve processes for an app as raw JSON
+
+  Scenario Outline: Retrieve processes
+    Given the process endpoint returns <json>
+    When I request processes for app <appId>
+    Then the process API returns <json>
+
+    Examples:
+      | appId | json           |
+      | app1  | {"procs":"p"} |

--- a/Common.UnitTests/ProcessApiTests.cs
+++ b/Common.UnitTests/ProcessApiTests.cs
@@ -1,0 +1,66 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Moq.Protected;
+
+namespace Common.UnitTests;
+
+public class ProcessApiTests
+{
+    [Fact]
+    public async Task GetProcessesAsync_ReturnsJson()
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"procs\":\"p\"}")
+            });
+        var services = new ServiceCollection();
+        services.AddSingleton<IProcessApi>(_ => new ProcessApi(new HttpClient(handler.Object), "http://localhost"));
+        var provider = services.BuildServiceProvider();
+        var api = provider.GetRequiredService<IProcessApi>();
+
+        var json = await api.GetProcessesAsync("app1");
+
+        Assert.Equal("{\"procs\":\"p\"}", json);
+    }
+
+    [Fact]
+    public async Task GetProcessesAsync_RefreshesTokenOnUnauthorized()
+    {
+        var refreshHandler = new Mock<HttpMessageHandler>();
+        refreshHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"access_token\":\"new\",\"refresh_token\":\"r2\"}")
+            });
+        var services = new ServiceCollection();
+        services.AddSingleton<ITokenRefresher>(_ =>
+            new TokenRefresher(new HttpClient(refreshHandler.Object), "http://localhost/refresh"));
+        var provider = services.BuildServiceProvider();
+        var refresher = provider.GetRequiredService<ITokenRefresher>();
+
+        var innerHandler = new Mock<HttpMessageHandler>();
+        innerHandler.Protected()
+            .SetupSequence<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.Unauthorized))
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"procs\":\"p\"}")
+            });
+
+        var handler = new TokenRefreshingHandler(refresher, new TokenModel { AccessToken = "old", RefreshToken = "r1" }, innerHandler.Object);
+        var api = new ProcessApi(new HttpClient(handler), "http://localhost");
+
+        var json = await api.GetProcessesAsync("app1");
+
+        Assert.Equal("{\"procs\":\"p\"}", json);
+        refreshHandler.Protected().Verify("SendAsync", Times.Once(), ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
+    }
+}

--- a/Common.UnitTests/ServiceCollectionExtensionsTests.cs
+++ b/Common.UnitTests/ServiceCollectionExtensionsTests.cs
@@ -16,9 +16,11 @@ public class ServiceCollectionExtensionsTests
         var client = provider.GetRequiredService<ITasClient>();
         var auth = provider.GetRequiredService<IAuthenticationService>();
         var api = provider.GetRequiredService<IFoundationApi>();
+        var process = provider.GetRequiredService<IProcessApi>();
 
         Assert.NotNull(client);
         Assert.NotNull(auth);
         Assert.NotNull(api);
+        Assert.NotNull(process);
     }
 }

--- a/Common/IProcessApi.cs
+++ b/Common/IProcessApi.cs
@@ -1,0 +1,28 @@
+using System.Net.Http;
+
+namespace Common;
+
+public interface IProcessApi
+{
+    Task<string> GetProcessesAsync(string appId);
+}
+
+public class ProcessApi : IProcessApi
+{
+    private readonly HttpClient _client;
+    private readonly string _baseUri;
+
+    public ProcessApi(HttpClient client, string baseUri)
+    {
+        _client = client;
+        _baseUri = baseUri.TrimEnd('/');
+    }
+
+    /// TASK: Get processes for an app as raw JSON
+    public async Task<string> GetProcessesAsync(string appId)
+    {
+        var resp = await _client.GetAsync($"{_baseUri}/v3/apps/{appId}/processes");
+        resp.EnsureSuccessStatusCode();
+        return await resp.Content.ReadAsStringAsync();
+    }
+}

--- a/Common/ITasClient.cs
+++ b/Common/ITasClient.cs
@@ -15,4 +15,7 @@ public interface ITasClient
 
     /// TASK: Retrieve apps for a specific space as raw JSON
     Task<string> GetAppsAsync(string spaceId);
+
+    /// TASK: Retrieve processes for a specific app as raw JSON
+    Task<string> GetProcessesAsync(string appId);
 }

--- a/Common/ServiceCollectionExtensions.cs
+++ b/Common/ServiceCollectionExtensions.cs
@@ -16,6 +16,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton(builder.FoundationApi!);
         services.AddSingleton(builder.OrgSpaceApi!);
         services.AddSingleton(builder.AppApi!);
+        services.AddSingleton(builder.ProcessApi!);
         services.AddSingleton<ITasClient>(client);
         return services;
     }

--- a/Common/TasClient.cs
+++ b/Common/TasClient.cs
@@ -6,13 +6,15 @@ public class TasClient : ITasClient
     private readonly IFoundationApi _foundationApi;
     private readonly IOrgSpaceApi _orgSpaceApi;
     private readonly IAppApi _appApi;
+    private readonly IProcessApi _processApi;
 
-    public TasClient(IAuthenticationService authService, IFoundationApi foundationApi, IOrgSpaceApi orgSpaceApi, IAppApi appApi)
+    public TasClient(IAuthenticationService authService, IFoundationApi foundationApi, IOrgSpaceApi orgSpaceApi, IAppApi appApi, IProcessApi processApi)
     {
         _authService = authService;
         _foundationApi = foundationApi;
         _orgSpaceApi = orgSpaceApi;
         _appApi = appApi;
+        _processApi = processApi;
     }
 
     /// TASK: Authenticate via AuthenticationService
@@ -34,4 +36,8 @@ public class TasClient : ITasClient
     /// TASK: Delegate to AppApi for apps
     public Task<string> GetAppsAsync(string spaceId)
         => _appApi.GetAppsAsync(spaceId);
+
+    /// TASK: Delegate to ProcessApi for processes
+    public Task<string> GetProcessesAsync(string appId)
+        => _processApi.GetProcessesAsync(appId);
 }

--- a/Common/TasClientBuilder.cs
+++ b/Common/TasClientBuilder.cs
@@ -11,6 +11,7 @@ public class TasClientBuilder
     public IFoundationApi? FoundationApi { get; private set; }
     public IOrgSpaceApi? OrgSpaceApi { get; private set; }
     public IAppApi? AppApi { get; private set; }
+    public IProcessApi? ProcessApi { get; private set; }
 
     public TasClientBuilder WithFoundationUri(string uri)
     {
@@ -33,6 +34,7 @@ public class TasClientBuilder
         FoundationApi = new FoundationApi(new HttpClient(), $"{_options.FoundationUri}/v3/info");
         OrgSpaceApi = new OrgSpaceApi(new HttpClient(), _options.FoundationUri.ToString());
         AppApi = new AppApi(new HttpClient(), _options.FoundationUri.ToString());
-        return new TasClient(AuthenticationService, FoundationApi, OrgSpaceApi, AppApi);
+        ProcessApi = new ProcessApi(new HttpClient(), _options.FoundationUri.ToString());
+        return new TasClient(AuthenticationService, FoundationApi, OrgSpaceApi, AppApi, ProcessApi);
     }
 }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository contains a basic .NET solution with a library, an example application and unit tests. The library now includes a HTTP message handler that automatically refreshes expired bearer tokens.
 It also supports initializing a `TasClient` using `TasClientBuilder` and registering it in dependency injection.
 The client can now retrieve foundation information through `FoundationApi`.
-It also supports authentication, token refresh and retrieving org and space data.
+It also supports authentication, token refresh and retrieving org, space, app and process data.
 
 ## Projects
 - **Common** - reusable library code.

--- a/docs/goals/dotnet-tas-client-sdk.md
+++ b/docs/goals/dotnet-tas-client-sdk.md
@@ -44,11 +44,11 @@ Status Table (auto-updated)
         - [x] Implement `AppApi.cs` → `GetAppsAsync(spaceId)` (raw JSON).
         - [x] Expose `TasClient.GetAppsAsync(spaceId)`.
         - [x] Add integration test `AppApiIntegrationTests.cs` for 200/404.
-    - [ ] **Story 4.2: Retrieve Process Info (`process-info.feature`)**
-        - [ ] Add BDD file `Common.Tests/BDD/process-info/process-info.feature`.
-        - [ ] Implement `ProcessApi.cs` → `GetProcessesAsync(appId)`.
-        - [ ] Expose `TasClient.GetProcessesAsync(appId)`.
-        - [ ] Validate token refresh on long-running calls in `ProcessApiTests.cs`.
+    - [x] **Story 4.2: Retrieve Process Info (`process-info.feature`)**
+        - [x] Add BDD file `Common.Tests/BDD/process-info/process-info.feature`.
+        - [x] Implement `ProcessApi.cs` → `GetProcessesAsync(appId)`.
+        - [x] Expose `TasClient.GetProcessesAsync(appId)`.
+        - [x] Validate token refresh on long-running calls in `ProcessApiTests.cs`.
 
 References  
 - Cloud Foundry v3 API Reference – all resources (apps, processes, orgs, spaces)  <https://v3-apidocs.cloudfoundry.org/>  


### PR DESCRIPTION
## Summary
- implement process API for retrieving app processes
- extend TasClient and builder to use new API
- register ProcessApi in DI
- cover token refresh path in unit tests
- add BDD scenario for processes
- document feature completion

## Testing
- `dotnet build -tl:off`
- `dotnet test -tl:off`
- `dotnet test Common.UnitTests/Common.UnitTests.csproj /p:CollectCoverage=true -tl:off`
- `dotnet test Common.Test/Common.Test.csproj /p:CollectCoverage=true -tl:off`


------
https://chatgpt.com/codex/tasks/task_e_6861b74b79cc8330905914c5c7ae2ba8