### PR TITLE
Add shared bearer token handler

### DIFF
--- a/Common.UnitTests/BearerTokenHandlerTests.cs
+++ b/Common.UnitTests/BearerTokenHandlerTests.cs
@@ -1,0 +1,31 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Moq.Protected;
+
+namespace Common.UnitTests;
+
+public class BearerTokenHandlerTests
+{
+    [Fact]
+    public async Task AddsAuthorizationHeader()
+    {
+        var cache = new Mock<ITokenCache>();
+        cache.SetupGet(c => c.Current).Returns(new TokenModel { AccessToken = "abc" });
+        HttpRequestMessage? captured = null;
+        var inner = new Mock<HttpMessageHandler>();
+        inner.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((m, _) => captured = m)
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+
+        var handler = new BearerTokenHandler(cache.Object, inner.Object);
+        var client = new HttpClient(handler);
+        await client.GetAsync("http://example.com");
+
+        Assert.Equal("Bearer", captured?.Headers.Authorization?.Scheme);
+        Assert.Equal("abc", captured?.Headers.Authorization?.Parameter);
+    }
+}

--- a/Common.UnitTests/ServiceCollectionExtensionsTests.cs
+++ b/Common.UnitTests/ServiceCollectionExtensionsTests.cs
@@ -17,10 +17,14 @@ public class ServiceCollectionExtensionsTests
         var auth = provider.GetRequiredService<IAuthenticationService>();
         var api = provider.GetRequiredService<IFoundationApi>();
         var process = provider.GetRequiredService<IProcessApi>();
+        var cache = provider.GetRequiredService<ITokenCache>();
+        var handler = provider.GetRequiredService<BearerTokenHandler>();
 
         Assert.NotNull(client);
         Assert.NotNull(auth);
         Assert.NotNull(api);
         Assert.NotNull(process);
+        Assert.NotNull(cache);
+        Assert.NotNull(handler);
     }
 }

--- a/Common.UnitTests/TasClientBuilderTests.cs
+++ b/Common.UnitTests/TasClientBuilderTests.cs
@@ -14,6 +14,10 @@ public class TasClientBuilderTests
         var client = builder.Build();
 
         Assert.NotNull(client);
+        Assert.Same(builder.HttpClient, typeof(FoundationApi).GetField("_client", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!.GetValue(builder.FoundationApi));
+        Assert.Same(builder.HttpClient, typeof(OrgSpaceApi).GetField("_client", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!.GetValue(builder.OrgSpaceApi));
+        Assert.Same(builder.HttpClient, typeof(AppApi).GetField("_client", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!.GetValue(builder.AppApi));
+        Assert.Same(builder.HttpClient, typeof(ProcessApi).GetField("_client", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!.GetValue(builder.ProcessApi));
     }
 
     [Fact]

--- a/Common/BearerTokenHandler.cs
+++ b/Common/BearerTokenHandler.cs
@@ -1,0 +1,23 @@
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+
+namespace Common;
+
+public class BearerTokenHandler : DelegatingHandler
+{
+    private readonly ITokenCache _cache;
+    public BearerTokenHandler(ITokenCache cache, HttpMessageHandler? innerHandler = null)
+    {
+        _cache = cache;
+        InnerHandler = innerHandler ?? new HttpClientHandler();
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var token = _cache.Current;
+        if (token != null && !string.IsNullOrEmpty(token.AccessToken))
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token.AccessToken);
+        return base.SendAsync(request, cancellationToken);
+    }
+}

--- a/Common/ITokenCache.cs
+++ b/Common/ITokenCache.cs
@@ -1,0 +1,19 @@
+using System.Threading;
+
+namespace Common;
+
+public interface ITokenCache
+{
+    TokenModel? Current { get; set; }
+}
+
+public class TokenCache : ITokenCache
+{
+    private readonly object _sync = new();
+    private TokenModel? _token;
+    public TokenModel? Current
+    {
+        get { lock(_sync) { return _token; } }
+        set { lock(_sync) { _token = value; } }
+    }
+}

--- a/Common/ServiceCollectionExtensions.cs
+++ b/Common/ServiceCollectionExtensions.cs
@@ -12,6 +12,9 @@ public static class ServiceCollectionExtensions
         var client = builder.Build();
 
         services.AddSingleton(builder.Options);
+        services.AddSingleton(builder.TokenCache!);
+        services.AddSingleton(builder.BearerHandler!);
+        services.AddSingleton(builder.HttpClient!);
         services.AddSingleton(builder.AuthenticationService!);
         services.AddSingleton(builder.FoundationApi!);
         services.AddSingleton(builder.OrgSpaceApi!);

--- a/Common/TasClientBuilder.cs
+++ b/Common/TasClientBuilder.cs
@@ -12,6 +12,9 @@ public class TasClientBuilder
     public IOrgSpaceApi? OrgSpaceApi { get; private set; }
     public IAppApi? AppApi { get; private set; }
     public IProcessApi? ProcessApi { get; private set; }
+    public ITokenCache? TokenCache { get; private set; }
+    public BearerTokenHandler? BearerHandler { get; private set; }
+    public HttpClient? HttpClient { get; private set; }
 
     public TasClientBuilder WithFoundationUri(string uri)
     {
@@ -31,10 +34,13 @@ public class TasClientBuilder
     {
         _options.Validate();
         AuthenticationService = new AuthenticationService(new HttpClient(), $"{_options.FoundationUri}/oauth/token");
-        FoundationApi = new FoundationApi(new HttpClient(), $"{_options.FoundationUri}/v3/info");
-        OrgSpaceApi = new OrgSpaceApi(new HttpClient(), _options.FoundationUri.ToString());
-        AppApi = new AppApi(new HttpClient(), _options.FoundationUri.ToString());
-        ProcessApi = new ProcessApi(new HttpClient(), _options.FoundationUri.ToString());
+        TokenCache = new TokenCache();
+        BearerHandler = new BearerTokenHandler(TokenCache);
+        HttpClient = new HttpClient(BearerHandler);
+        FoundationApi = new FoundationApi(HttpClient, $"{_options.FoundationUri}/v3/info");
+        OrgSpaceApi = new OrgSpaceApi(HttpClient, _options.FoundationUri.ToString());
+        AppApi = new AppApi(HttpClient, _options.FoundationUri.ToString());
+        ProcessApi = new ProcessApi(HttpClient, _options.FoundationUri.ToString());
         return new TasClient(AuthenticationService, FoundationApi, OrgSpaceApi, AppApi, ProcessApi);
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Common Solution
 
-This repository contains a basic .NET solution with a library, an example application and unit tests. The library now includes a HTTP message handler that automatically refreshes expired bearer tokens.
+This repository contains a basic .NET solution with a library, an example application and unit tests. The library now includes HTTP message handlers that automatically refresh expired bearer tokens and inject the current access token into every request.
 It also supports initializing a `TasClient` using `TasClientBuilder` and registering it in dependency injection.
 The client can now retrieve foundation information through `FoundationApi`.
 It also supports authentication, token refresh and retrieving org, space, app and process data.
+All API calls share a single `HttpClient` that applies the current bearer token via `BearerTokenHandler`.
 
 ## Projects
 - **Common** - reusable library code.


### PR DESCRIPTION
## Summary
- add `BearerTokenHandler` to inject `Authorization` header
- track bearer token in thread-safe `TokenCache`
- share a single `HttpClient` through `TasClientBuilder`
- register new services via `AddTasClient`
- cover new handler with unit tests and document in README

## Testing
- `dotnet test Common.UnitTests/Common.UnitTests.csproj /p:CollectCoverage=true`
- `dotnet test Common.Test/Common.Test.csproj /p:CollectCoverage=true`
- `dotnet restore`

------
https://chatgpt.com/codex/tasks/task_e_6861d02cd0008330b43efaa42e9aac56