### PR TITLE
Fix AuthenticationService token URI

### DIFF
--- a/Common.Tests/BDD/token-endpoint-discovery/token-endpoint-discovery.feature
+++ b/Common.Tests/BDD/token-endpoint-discovery/token-endpoint-discovery.feature
@@ -6,7 +6,7 @@ Feature: Token Endpoint Discovery
   Scenario Outline: Discover and use token endpoint
     Given the info endpoint returns <token_url>
     When I authenticate with <username> and <password>
-    Then the token request is sent to <token_url>/oauth/token
+    Then the token request is sent to <token_url>
 
     Examples:
       | username | password | token_url             |

--- a/Common.UnitTests/TasClientBuilderTests.cs
+++ b/Common.UnitTests/TasClientBuilderTests.cs
@@ -14,6 +14,12 @@ public class TasClientBuilderTests
         var client = builder.Build();
 
         Assert.NotNull(client);
+        Assert.Equal("https://api.tas", typeof(AuthenticationService)
+            .GetField("_foundationUri", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .GetValue(builder.AuthenticationService));
+        Assert.Equal("https://api.tas/v3/info", typeof(FoundationApi)
+            .GetField("_endpoint", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .GetValue(builder.FoundationApi));
         Assert.Same(builder.HttpClient, typeof(FoundationApi).GetField("_client", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!.GetValue(builder.FoundationApi));
         Assert.Same(builder.HttpClient, typeof(OrgSpaceApi).GetField("_client", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!.GetValue(builder.OrgSpaceApi));
         Assert.Same(builder.HttpClient, typeof(AppApi).GetField("_client", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!.GetValue(builder.AppApi));
@@ -25,6 +31,16 @@ public class TasClientBuilderTests
     {
         var builder = new TasClientBuilder()
             .WithFoundationUri("https://api.tas");
+
+        Assert.Throws<InvalidOperationException>(() => builder.Build());
+    }
+
+    [Fact]
+    public void Build_ThrowsWithTrailingSlashUri()
+    {
+        var builder = new TasClientBuilder()
+            .WithFoundationUri("https://api.tas/")
+            .WithCredentials("u", "p");
 
         Assert.Throws<InvalidOperationException>(() => builder.Build());
     }

--- a/Common/AuthenticationService.cs
+++ b/Common/AuthenticationService.cs
@@ -27,7 +27,7 @@ public class AuthenticationService : IAuthenticationService
         var endpoint = doc.RootElement.TryGetProperty("token_endpoint", out var te)
             ? te.GetString()
             : doc.RootElement.GetProperty("authorization_endpoint").GetString();
-        var tokenUri = $"{endpoint?.TrimEnd('/')}/oauth/token";
+        var tokenUri = endpoint?.TrimEnd('/');
 
         var request = new HttpRequestMessage(HttpMethod.Post, tokenUri);
         request.Headers.Authorization = new AuthenticationHeaderValue("Basic", "Y2Y6");
@@ -56,7 +56,7 @@ public class AuthenticationService : IAuthenticationService
         var endpoint = doc.RootElement.TryGetProperty("token_endpoint", out var te)
             ? te.GetString()
             : doc.RootElement.GetProperty("authorization_endpoint").GetString();
-        var tokenUri = $"{endpoint?.TrimEnd('/')}/oauth/token";
+        var tokenUri = endpoint?.TrimEnd('/');
 
         var request = new HttpRequestMessage(HttpMethod.Post, tokenUri);
         request.Headers.Authorization = new AuthenticationHeaderValue("Basic", "Y2Y6");

--- a/Common/TasClientBuilder.cs
+++ b/Common/TasClientBuilder.cs
@@ -33,14 +33,15 @@ public class TasClientBuilder
     public TasClient Build()
     {
         _options.Validate();
-        AuthenticationService = new AuthenticationService(new HttpClient(), _options.FoundationUri.ToString());
+        var baseUri = _options.FoundationUri.ToString().TrimEnd('/');
+        AuthenticationService = new AuthenticationService(new HttpClient(), baseUri);
         TokenCache = new TokenCache();
         BearerHandler = new BearerTokenHandler(TokenCache, AuthenticationService);
         HttpClient = new HttpClient(BearerHandler);
-        FoundationApi = new FoundationApi(HttpClient, $"{_options.FoundationUri}/v3/info");
-        OrgSpaceApi = new OrgSpaceApi(HttpClient, _options.FoundationUri.ToString());
-        AppApi = new AppApi(HttpClient, _options.FoundationUri.ToString());
-        ProcessApi = new ProcessApi(HttpClient, _options.FoundationUri.ToString());
+        FoundationApi = new FoundationApi(HttpClient, $"{baseUri}/v3/info");
+        OrgSpaceApi = new OrgSpaceApi(HttpClient, baseUri);
+        AppApi = new AppApi(HttpClient, baseUri);
+        ProcessApi = new ProcessApi(HttpClient, baseUri);
         return new TasClient(AuthenticationService, FoundationApi, OrgSpaceApi, AppApi, ProcessApi);
     }
 }

--- a/Common/TasClientOptions.cs
+++ b/Common/TasClientOptions.cs
@@ -13,6 +13,8 @@ public class TasClientOptions
     {
         if (FoundationUri == null)
             throw new InvalidOperationException("FoundationUri is required");
+        if (FoundationUri.OriginalString.EndsWith("/"))
+            throw new InvalidOperationException("FoundationUri must not have a trailing slash");
         if (string.IsNullOrWhiteSpace(Username))
             throw new InvalidOperationException("Username is required");
         if (string.IsNullOrWhiteSpace(Password))


### PR DESCRIPTION
## Summary
- stop appending `/oauth/token` for token endpoint
- enforce no trailing slash in `TasClientOptions`
- trim base URIs in `TasClientBuilder`
- adjust token discovery feature
- update builder tests for endpoint expectations

## Testing
- `dotnet test -tl:off`
- `dotnet test Common.UnitTests/Common.UnitTests.csproj --collect:"XPlat Code Coverage"`
- `dotnet test Common.Test/Common.Test.csproj --collect:"XPlat Code Coverage"`


------
https://chatgpt.com/codex/tasks/task_e_6861d6ad805c833090a2762b1c8074de