### PR TITLE
Implement pagination helper for OrgSpaceApi

### DIFF
--- a/Common.Test/OrgSpaceApiIntegrationTests.cs
+++ b/Common.Test/OrgSpaceApiIntegrationTests.cs
@@ -1,0 +1,34 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Common.Test;
+
+public class OrgSpaceApiIntegrationTests
+{
+    [Fact]
+    public async Task GetAllOrgsAsync_MergesPages()
+    {
+        var handler = new SequenceHandler(
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"resources\":[{\"id\":1}],\"pagination\":{\"next\":{\"href\":\"http://next\"}}}")
+            },
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"resources\":[{\"id\":2}],\"pagination\":{\"next\":{\"href\":null}}}")
+            });
+        var services = new ServiceCollection();
+        services.AddSingleton<IOrgSpaceApi>(_ => new OrgSpaceApi(new HttpClient(handler), "http://localhost"));
+        var provider = services.BuildServiceProvider();
+        var api = provider.GetRequiredService<IOrgSpaceApi>();
+
+        var json = await api.GetAllOrgsAsync();
+
+        Assert.Contains("\"id\":1", json);
+        Assert.Contains("\"id\":2", json);
+    }
+}

--- a/Common/IOrgSpaceApi.cs
+++ b/Common/IOrgSpaceApi.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http;
+using System.Text.Json.Nodes;
 
 namespace Common;
 
@@ -34,9 +35,40 @@ public class OrgSpaceApi : IOrgSpaceApi
         return string.Empty;
     }
 
-    /// TASK: Get all orgs as raw JSON with simple retry
-    public Task<string> GetAllOrgsAsync() => GetWithRetryAsync($"{_baseUri}/v3/organizations");
+    private async Task<string> GetPagedJsonAsync(string url)
+    {
+        JsonObject? root = null;
+        var all = new JsonArray();
+        var next = url;
+        var firstJson = await GetWithRetryAsync(next);
+        var node = JsonNode.Parse(firstJson)!.AsObject();
+        if (node["pagination"] is null)
+            return firstJson;
+        root = node;
+        if (node["resources"] is JsonArray firstItems)
+            foreach (var r in firstItems)
+                all.Add(r.DeepClone());
+        next = node["pagination"]?["next"]?["href"]?.GetValue<string>();
+        while (!string.IsNullOrEmpty(next))
+        {
+            var json = await GetWithRetryAsync(next);
+            var page = JsonNode.Parse(json)!.AsObject();
+            if (page["resources"] is JsonArray items)
+                foreach (var r in items)
+                    all.Add(r.DeepClone());
+            next = page["pagination"]?["next"]?["href"]?.GetValue<string>();
+        }
 
-    /// TASK: Get spaces for an org as raw JSON with simple retry
-    public Task<string> GetSpacesForOrgAsync(string orgId) => GetWithRetryAsync($"{_baseUri}/v3/organizations/{orgId}/spaces");
+        root["resources"] = all;
+        if (root["pagination"]?["next"] is JsonObject nextObj)
+            nextObj["href"] = null;
+
+        return root.ToJsonString();
+    }
+
+    /// TASK: Get all orgs as raw JSON with pagination
+    public Task<string> GetAllOrgsAsync() => GetPagedJsonAsync($"{_baseUri}/v3/organizations");
+
+    /// TASK: Get spaces for an org as raw JSON with pagination
+    public Task<string> GetSpacesForOrgAsync(string orgId) => GetPagedJsonAsync($"{_baseUri}/v3/organizations/{orgId}/spaces");
 }


### PR DESCRIPTION
## Summary
- create `GetPagedJsonAsync` in `OrgSpaceApi` to walk `pagination.next.href`
- call helper from `GetAllOrgsAsync` and `GetSpacesForOrgAsync`
- add integration test covering multiple pages

## Testing
- `dotnet test -tl:off`
- `dotnet test Common.UnitTests/Common.UnitTests.csproj /p:CollectCoverage=true -tl:off`
- `dotnet test Common.Test/Common.Test.csproj /p:CollectCoverage=true -tl:off`


------
https://chatgpt.com/codex/tasks/task_e_686284030dac83309ccff988275c96d2