### PR TITLE
Fix build and enable analyzer tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*.cs]
+dotnet_style_require_accessibility_modifiers = always
+dotnet_style_qualification_for_field = false
+dotnet_style_prefer_explicit_type_in_member_access = true
+dotnet_default_accessibility_modifier = internal

--- a/CodingStandards.sln
+++ b/CodingStandards.sln
@@ -1,0 +1,62 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CodingStandards.Analyzers", "CodingStandards.Analyzers", "{5D3862BC-D07F-FC0C-C7E0-6C7D2D9692D8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CodingStandards.Analyzers", "src\CodingStandards.Analyzers\CodingStandards.Analyzers\CodingStandards.Analyzers.csproj", "{F806B41C-5882-463D-BF85-BFD1E5D5FAD2}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{0C88DD14-F956-CE84-757C-A364CCF449FC}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CodingStandards.Analyzers.Tests", "CodingStandards.Analyzers.Tests", "{C9C89658-CA16-8175-1382-299D7C912387}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CodingStandards.Analyzers.Tests", "test\CodingStandards.Analyzers.Tests\CodingStandards.Analyzers.Tests\CodingStandards.Analyzers.Tests.csproj", "{12E1B447-F5B6-4769-B741-61EC1CCAD56B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F806B41C-5882-463D-BF85-BFD1E5D5FAD2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F806B41C-5882-463D-BF85-BFD1E5D5FAD2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F806B41C-5882-463D-BF85-BFD1E5D5FAD2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F806B41C-5882-463D-BF85-BFD1E5D5FAD2}.Debug|x64.Build.0 = Debug|Any CPU
+		{F806B41C-5882-463D-BF85-BFD1E5D5FAD2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F806B41C-5882-463D-BF85-BFD1E5D5FAD2}.Debug|x86.Build.0 = Debug|Any CPU
+		{F806B41C-5882-463D-BF85-BFD1E5D5FAD2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F806B41C-5882-463D-BF85-BFD1E5D5FAD2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F806B41C-5882-463D-BF85-BFD1E5D5FAD2}.Release|x64.ActiveCfg = Release|Any CPU
+		{F806B41C-5882-463D-BF85-BFD1E5D5FAD2}.Release|x64.Build.0 = Release|Any CPU
+		{F806B41C-5882-463D-BF85-BFD1E5D5FAD2}.Release|x86.ActiveCfg = Release|Any CPU
+		{F806B41C-5882-463D-BF85-BFD1E5D5FAD2}.Release|x86.Build.0 = Release|Any CPU
+		{12E1B447-F5B6-4769-B741-61EC1CCAD56B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{12E1B447-F5B6-4769-B741-61EC1CCAD56B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{12E1B447-F5B6-4769-B741-61EC1CCAD56B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{12E1B447-F5B6-4769-B741-61EC1CCAD56B}.Debug|x64.Build.0 = Debug|Any CPU
+		{12E1B447-F5B6-4769-B741-61EC1CCAD56B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{12E1B447-F5B6-4769-B741-61EC1CCAD56B}.Debug|x86.Build.0 = Debug|Any CPU
+		{12E1B447-F5B6-4769-B741-61EC1CCAD56B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{12E1B447-F5B6-4769-B741-61EC1CCAD56B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{12E1B447-F5B6-4769-B741-61EC1CCAD56B}.Release|x64.ActiveCfg = Release|Any CPU
+		{12E1B447-F5B6-4769-B741-61EC1CCAD56B}.Release|x64.Build.0 = Release|Any CPU
+		{12E1B447-F5B6-4769-B741-61EC1CCAD56B}.Release|x86.ActiveCfg = Release|Any CPU
+		{12E1B447-F5B6-4769-B741-61EC1CCAD56B}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{5D3862BC-D07F-FC0C-C7E0-6C7D2D9692D8} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{F806B41C-5882-463D-BF85-BFD1E5D5FAD2} = {5D3862BC-D07F-FC0C-C7E0-6C7D2D9692D8}
+		{C9C89658-CA16-8175-1382-299D7C912387} = {0C88DD14-F956-CE84-757C-A364CCF449FC}
+		{12E1B447-F5B6-4769-B741-61EC1CCAD56B} = {C9C89658-CA16-8175-1382-299D7C912387}
+	EndGlobalSection
+EndGlobal

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+</Project>

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction...

--- a/README.md
+++ b/README.md
@@ -1,25 +1,23 @@
-# Common Solution
+# CodingStandards Analyzers
 
-This repository contains a basic .NET solution with a library, an example application and unit tests.
+This package provides Roslyn analyzers enforcing common coding standards.
 
-## Projects
-- **Common** - reusable library code.
-- **Common.Example** - console application demonstrating library usage.
-- **Common.UnitTests** - xUnit project containing all unit tests. Tests rely on `Moq` for mocking.
+## Rules
 
-## Building
-Run the build command before executing any tests. The `-tl:off` option
-disables the terminal logger which can fail in non-interactive shells:
-
-```bash
-dotnet build -tl:off
-```
-
-## Running Tests
-After building, execute the tests with the terminal logger disabled:
-
-```bash
-dotnet test -tl:off
-```
-
-The build step ensures that all projects compile successfully prior to running the test suite.
+| ID | Title | Auto-fix |
+|----|-------|----------|
+| CSAD0001 | Use strong typing | Yes |
+| CSAD0002 | Encapsulate HttpClient | No |
+| CSAD0003 | Use constructor injection | No |
+| CSAD0004 | Expose service via interface | No |
+| CSAD0005 | Business logic should be in services | No |
+| CSAD0006 | No business logic in controllers | No |
+| CSAD0007 | Use record for DTO | Yes |
+| CSAD0008 | Use dedicated validators | No |
+| CSAD0009 | Place interfaces in Abstractions | No |
+| CSAD0010 | Use BDD naming | No |
+| CSAD0011 | Use async/await | No |
+| CSAD0012 | Do not swallow exceptions | No |
+| CSAD0013 | Inject feature flags | No |
+| CSAD0014 | Keep Program/Startup thin | No |
+| CSAD0015 | Prefer internal | No |

--- a/src/CodingStandards.Analyzers/CodingStandards.Analyzers/Analyzers/Rules/AsyncAwaitAnalyzer.cs
+++ b/src/CodingStandards.Analyzers/CodingStandards.Analyzers/Analyzers/Rules/AsyncAwaitAnalyzer.cs
@@ -1,0 +1,53 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace CodingStandards.Analyzers.Rules
+{
+    /// <summary>
+    /// Disallows synchronous wait of async operations.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class AsyncAwaitAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "CSAD0011";
+        private static readonly DiagnosticDescriptor Rule = new(
+            DiagnosticId,
+            "Use async/await",
+            "Avoid synchronous wait on Task; use await",
+            "Reliability",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        /// <inheritdoc />
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        /// <inheritdoc />
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.RegisterSyntaxNodeAction(AnalyzeMemberAccess, SyntaxKind.SimpleMemberAccessExpression, SyntaxKind.InvocationExpression);
+        }
+
+        private static void AnalyzeMemberAccess(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is MemberAccessExpressionSyntax member)
+            {
+                if (member.Name.Identifier.Text == "Result")
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(Rule, member.Name.GetLocation()));
+                }
+            }
+            else if (context.Node is InvocationExpressionSyntax invocation && invocation.Expression is MemberAccessExpressionSyntax mae)
+            {
+                if (mae.Name.Identifier.Text == "Wait" && invocation.ArgumentList.Arguments.Count == 0)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(Rule, mae.Name.GetLocation()));
+                }
+            }
+        }
+    }
+}

--- a/src/CodingStandards.Analyzers/CodingStandards.Analyzers/Analyzers/Rules/BddTestNamingAnalyzer.cs
+++ b/src/CodingStandards.Analyzers/CodingStandards.Analyzers/Analyzers/Rules/BddTestNamingAnalyzer.cs
@@ -1,0 +1,50 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace CodingStandards.Analyzers.Rules
+{
+    /// <summary>
+    /// Enforces BDD naming pattern for test methods.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class BddTestNamingAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "CSAD0010";
+        private static readonly DiagnosticDescriptor Rule = new(
+            DiagnosticId,
+            "Use BDD naming",
+            "Test method '{0}' should follow Given_When_Then pattern",
+            "Naming",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        /// <inheritdoc />
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        /// <inheritdoc />
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.RegisterSyntaxNodeAction(AnalyzeMethod, SyntaxKind.MethodDeclaration);
+        }
+
+        private static void AnalyzeMethod(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is MethodDeclarationSyntax method && method.Modifiers.Any(SyntaxKind.PublicKeyword))
+            {
+                var cls = method.FirstAncestorOrSelf<ClassDeclarationSyntax>();
+                if (cls != null && cls.AttributeLists.Any(al => al.Attributes.Any(a => a.Name.ToString().Contains("Fact") || a.Name.ToString().Contains("Theory"))))
+                {
+                    if (!method.Identifier.Text.Contains("_"))
+                    {
+                        context.ReportDiagnostic(Diagnostic.Create(Rule, method.Identifier.GetLocation(), method.Identifier.Text));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/CodingStandards.Analyzers/CodingStandards.Analyzers/Analyzers/Rules/BusinessLogicServiceAnalyzer.cs
+++ b/src/CodingStandards.Analyzers/CodingStandards.Analyzers/Analyzers/Rules/BusinessLogicServiceAnalyzer.cs
@@ -1,0 +1,50 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace CodingStandards.Analyzers.Rules
+{
+    /// <summary>
+    /// Ensures business logic resides in service classes.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class BusinessLogicServiceAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "CSAD0005";
+        private static readonly DiagnosticDescriptor Rule = new(
+            DiagnosticId,
+            "Business logic should be in services",
+            "Method '{0}' contains multiple statements and should reside in a service class",
+            "Design",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        /// <inheritdoc />
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        /// <inheritdoc />
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.RegisterSyntaxNodeAction(AnalyzeMethod, SyntaxKind.MethodDeclaration);
+        }
+
+        private static void AnalyzeMethod(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is MethodDeclarationSyntax method && method.Body != null)
+            {
+                var cls = method.FirstAncestorOrSelf<ClassDeclarationSyntax>();
+                if (cls != null && (cls.Identifier.Text.EndsWith("Controller") || cls.Identifier.Text.EndsWith("Middleware")))
+                {
+                    if (method.Body.Statements.Count > 1)
+                    {
+                        context.ReportDiagnostic(Diagnostic.Create(Rule, method.Identifier.GetLocation(), method.Identifier.Text));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/CodingStandards.Analyzers/CodingStandards.Analyzers/Analyzers/Rules/ConstructorInjectionAnalyzer.cs
+++ b/src/CodingStandards.Analyzers/CodingStandards.Analyzers/Analyzers/Rules/ConstructorInjectionAnalyzer.cs
@@ -1,0 +1,47 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace CodingStandards.Analyzers.Rules
+{
+    /// <summary>
+    /// Enforces constructor injection for dependencies.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class ConstructorInjectionAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "CSAD0003";
+        private static readonly DiagnosticDescriptor Rule = new(
+            DiagnosticId,
+            "Use constructor injection",
+            "Property injection is not allowed. Use constructor injection.",
+            "Design",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        /// <inheritdoc />
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        /// <inheritdoc />
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.RegisterSyntaxNodeAction(AnalyzeProperty, SyntaxKind.PropertyDeclaration);
+        }
+
+        private static void AnalyzeProperty(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is PropertyDeclarationSyntax prop)
+            {
+                if (prop.AccessorList?.Accessors.Any(a => a.Kind() == SyntaxKind.SetAccessorDeclaration) == true &&
+                    prop.Modifiers.Any(m => m.IsKind(SyntaxKind.PublicKeyword)))
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(Rule, prop.GetLocation()));
+                }
+            }
+        }
+    }
+}

--- a/src/CodingStandards.Analyzers/CodingStandards.Analyzers/Analyzers/Rules/DefaultInternalAnalyzer.cs
+++ b/src/CodingStandards.Analyzers/CodingStandards.Analyzers/Analyzers/Rules/DefaultInternalAnalyzer.cs
@@ -1,0 +1,48 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace CodingStandards.Analyzers.Rules
+{
+    /// <summary>
+    /// Encourages internal over public visibility.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class DefaultInternalAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "CSAD0015";
+        private static readonly DiagnosticDescriptor Rule = new(
+            DiagnosticId,
+            "Prefer internal",
+            "Member '{0}' is public. Consider reducing visibility.",
+            "Design",
+            DiagnosticSeverity.Info,
+            isEnabledByDefault: true);
+
+        /// <inheritdoc />
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        /// <inheritdoc />
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.RegisterSyntaxNodeAction(AnalyzeMember, SyntaxKind.ClassDeclaration, SyntaxKind.MethodDeclaration);
+        }
+
+        private static void AnalyzeMember(SyntaxNodeAnalysisContext context)
+        {
+            switch (context.Node)
+            {
+                case ClassDeclarationSyntax cls when cls.Modifiers.Any(SyntaxKind.PublicKeyword):
+                    context.ReportDiagnostic(Diagnostic.Create(Rule, cls.Identifier.GetLocation(), cls.Identifier.Text));
+                    break;
+                case MethodDeclarationSyntax method when method.Modifiers.Any(SyntaxKind.PublicKeyword):
+                    context.ReportDiagnostic(Diagnostic.Create(Rule, method.Identifier.GetLocation(), method.Identifier.Text));
+                    break;
+            }
+        }
+    }
+}

--- a/src/CodingStandards.Analyzers/CodingStandards.Analyzers/Analyzers/Rules/ExceptionLoggingAnalyzer.cs
+++ b/src/CodingStandards.Analyzers/CodingStandards.Analyzers/Analyzers/Rules/ExceptionLoggingAnalyzer.cs
@@ -1,0 +1,48 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace CodingStandards.Analyzers.Rules
+{
+    /// <summary>
+    /// Ensures exceptions are logged when caught.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class ExceptionLoggingAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "CSAD0012";
+        private static readonly DiagnosticDescriptor Rule = new(
+            DiagnosticId,
+            "Do not swallow exceptions",
+            "Exceptions should be logged with contextual data",
+            "Reliability",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        /// <inheritdoc />
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        /// <inheritdoc />
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.RegisterSyntaxNodeAction(AnalyzeCatch, SyntaxKind.CatchClause);
+        }
+
+        private static void AnalyzeCatch(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is CatchClauseSyntax cc && cc.Block != null)
+            {
+                var hasLog = cc.Block.DescendantNodes().OfType<InvocationExpressionSyntax>()
+                    .Any(inv => inv.Expression.ToString().Contains("Log"));
+                if (!hasLog)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(Rule, cc.CatchKeyword.GetLocation()));
+                }
+            }
+        }
+    }
+}

--- a/src/CodingStandards.Analyzers/CodingStandards.Analyzers/Analyzers/Rules/FeatureFlagAnalyzer.cs
+++ b/src/CodingStandards.Analyzers/CodingStandards.Analyzers/Analyzers/Rules/FeatureFlagAnalyzer.cs
@@ -1,0 +1,43 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace CodingStandards.Analyzers.Rules
+{
+    /// <summary>
+    /// Requires feature flags to be injected rather than read from configuration directly.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class FeatureFlagAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "CSAD0013";
+        private static readonly DiagnosticDescriptor Rule = new(
+            DiagnosticId,
+            "Inject feature flags",
+            "Feature flags should be injected, not read via Configuration[index]",
+            "Design",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        /// <inheritdoc />
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        /// <inheritdoc />
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.RegisterSyntaxNodeAction(AnalyzeIndexer, SyntaxKind.ElementAccessExpression);
+        }
+
+        private static void AnalyzeIndexer(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is ElementAccessExpressionSyntax ea && ea.Expression.ToString().Contains("Configuration"))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(Rule, ea.GetLocation()));
+            }
+        }
+    }
+}

--- a/src/CodingStandards.Analyzers/CodingStandards.Analyzers/Analyzers/Rules/HttpClientEncapsulationAnalyzer.cs
+++ b/src/CodingStandards.Analyzers/CodingStandards.Analyzers/Analyzers/Rules/HttpClientEncapsulationAnalyzer.cs
@@ -1,0 +1,67 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace CodingStandards.Analyzers.Rules
+{
+    /// <summary>
+    /// Ensures HttpClient usage is wrapped in typed clients.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class HttpClientEncapsulationAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "CSAD0002";
+        private static readonly DiagnosticDescriptor Rule = new(
+            DiagnosticId,
+            "Encapsulate HttpClient",
+            "HttpClient should only be used within classes implementing an I*Client interface",
+            "Design",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        /// <inheritdoc />
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        /// <inheritdoc />
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.RegisterSyntaxNodeAction(AnalyzeNew, SyntaxKind.ObjectCreationExpression);
+        }
+
+        private static void AnalyzeNew(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is ObjectCreationExpressionSyntax oces)
+            {
+                var type = context.SemanticModel.GetTypeInfo(oces).Type;
+                if (type?.Name == "HttpClient")
+                {
+                    var classDecl = oces.FirstAncestorOrSelf<ClassDeclarationSyntax>();
+                    if (classDecl == null)
+                    {
+                        return;
+                    }
+
+                    var implementsClient = false;
+                    foreach (var baseType in classDecl.BaseList?.Types ?? default)
+                    {
+                        var t = context.SemanticModel.GetTypeInfo(baseType.Type).Type as INamedTypeSymbol;
+                        if (t?.TypeKind == TypeKind.Interface && t.Name.StartsWith("I") && t.Name.EndsWith("Client"))
+                        {
+                            implementsClient = true;
+                            break;
+                        }
+                    }
+
+                    if (!implementsClient)
+                    {
+                        context.ReportDiagnostic(Diagnostic.Create(Rule, oces.GetLocation()));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/CodingStandards.Analyzers/CodingStandards.Analyzers/Analyzers/Rules/InputValidationAnalyzer.cs
+++ b/src/CodingStandards.Analyzers/CodingStandards.Analyzers/Analyzers/Rules/InputValidationAnalyzer.cs
@@ -1,0 +1,47 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace CodingStandards.Analyzers.Rules
+{
+    /// <summary>
+    /// Flags manual input validation in controllers.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class InputValidationAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "CSAD0008";
+        private static readonly DiagnosticDescriptor Rule = new(
+            DiagnosticId,
+            "Use dedicated validators",
+            "Input validation should be performed using validator classes",
+            "Design",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        /// <inheritdoc />
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        /// <inheritdoc />
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.RegisterSyntaxNodeAction(AnalyzeIf, SyntaxKind.IfStatement);
+        }
+
+        private static void AnalyzeIf(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is IfStatementSyntax ifs)
+            {
+                var cls = ifs.FirstAncestorOrSelf<ClassDeclarationSyntax>();
+                if (cls != null && cls.Identifier.Text.EndsWith("Controller"))
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(Rule, ifs.IfKeyword.GetLocation()));
+                }
+            }
+        }
+    }
+}

--- a/src/CodingStandards.Analyzers/CodingStandards.Analyzers/Analyzers/Rules/InterfaceExposureAnalyzer.cs
+++ b/src/CodingStandards.Analyzers/CodingStandards.Analyzers/Analyzers/Rules/InterfaceExposureAnalyzer.cs
@@ -1,0 +1,47 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace CodingStandards.Analyzers.Rules
+{
+    /// <summary>
+    /// Ensures services are exposed behind an interface with I prefix.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class InterfaceExposureAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "CSAD0004";
+        private static readonly DiagnosticDescriptor Rule = new(
+            DiagnosticId,
+            "Expose service via interface",
+            "Public class '{0}' should be accessed via an interface starting with 'I'",
+            "Design",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        /// <inheritdoc />
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        /// <inheritdoc />
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.RegisterSyntaxNodeAction(AnalyzeClass, SyntaxKind.ClassDeclaration);
+        }
+
+        private static void AnalyzeClass(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is ClassDeclarationSyntax cls && cls.Modifiers.Any(SyntaxKind.PublicKeyword))
+            {
+                var implements = cls.BaseList?.Types.Select(t => context.SemanticModel.GetTypeInfo(t.Type).Type as INamedTypeSymbol);
+                if (implements is null || !implements.Any(t => t?.TypeKind == TypeKind.Interface && t.Name.StartsWith("I")))
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(Rule, cls.Identifier.GetLocation(), cls.Identifier.Text));
+                }
+            }
+        }
+    }
+}

--- a/src/CodingStandards.Analyzers/CodingStandards.Analyzers/Analyzers/Rules/InterfaceNamespaceAnalyzer.cs
+++ b/src/CodingStandards.Analyzers/CodingStandards.Analyzers/Analyzers/Rules/InterfaceNamespaceAnalyzer.cs
@@ -1,0 +1,47 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace CodingStandards.Analyzers.Rules
+{
+    /// <summary>
+    /// Requires service interfaces to reside in Abstractions namespace.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class InterfaceNamespaceAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "CSAD0009";
+        private static readonly DiagnosticDescriptor Rule = new(
+            DiagnosticId,
+            "Place interfaces in Abstractions",
+            "Interface '{0}' should be declared in a namespace containing 'Abstractions'",
+            "Design",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        /// <inheritdoc />
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        /// <inheritdoc />
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.RegisterSyntaxNodeAction(AnalyzeInterface, SyntaxKind.InterfaceDeclaration);
+        }
+
+        private static void AnalyzeInterface(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is InterfaceDeclarationSyntax iface)
+            {
+                var ns = iface.FirstAncestorOrSelf<NamespaceDeclarationSyntax>();
+                if (ns == null || !ns.Name.ToString().Contains("Abstractions"))
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(Rule, iface.Identifier.GetLocation(), iface.Identifier.Text));
+                }
+            }
+        }
+    }
+}

--- a/src/CodingStandards.Analyzers/CodingStandards.Analyzers/Analyzers/Rules/NoBusinessInControllersAnalyzer.cs
+++ b/src/CodingStandards.Analyzers/CodingStandards.Analyzers/Analyzers/Rules/NoBusinessInControllersAnalyzer.cs
@@ -1,0 +1,50 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace CodingStandards.Analyzers.Rules
+{
+    /// <summary>
+    /// Detects business logic placed in controllers or middleware.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class NoBusinessInControllersAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "CSAD0006";
+        private static readonly DiagnosticDescriptor Rule = new(
+            DiagnosticId,
+            "No business logic in controllers",
+            "Method '{0}' should delegate to a service instead of containing logic",
+            "Design",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        /// <inheritdoc />
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        /// <inheritdoc />
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.RegisterSyntaxNodeAction(AnalyzeMethod, SyntaxKind.MethodDeclaration);
+        }
+
+        private static void AnalyzeMethod(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is MethodDeclarationSyntax method && method.Body != null)
+            {
+                var cls = method.FirstAncestorOrSelf<ClassDeclarationSyntax>();
+                if (cls != null && (cls.Identifier.Text.EndsWith("Controller") || cls.Identifier.Text.EndsWith("Middleware")))
+                {
+                    if (method.Body.Statements.Count > 1)
+                    {
+                        context.ReportDiagnostic(Diagnostic.Create(Rule, method.Identifier.GetLocation(), method.Identifier.Text));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/CodingStandards.Analyzers/CodingStandards.Analyzers/Analyzers/Rules/StrongTypingAnalyzer.cs
+++ b/src/CodingStandards.Analyzers/CodingStandards.Analyzers/Analyzers/Rules/StrongTypingAnalyzer.cs
@@ -1,0 +1,101 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.CodeActions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CodingStandards.Analyzers.Rules
+{
+    /// <summary>
+    /// Analyzer to prohibit usage of dynamic or object types.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class StrongTypingAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "CSAD0001";
+        private static readonly DiagnosticDescriptor Rule = new(
+            DiagnosticId,
+            title: "Use strong typing",
+            messageFormat: "Type '{0}' is not allowed; use a strongly typed alternative",
+            category: "Design",
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        /// <inheritdoc />
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        /// <inheritdoc />
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.RegisterSyntaxNodeAction(AnalyzeType, SyntaxKind.IdentifierName, SyntaxKind.PredefinedType);
+        }
+
+        private static void AnalyzeType(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is PredefinedTypeSyntax pts && pts.Keyword.IsKind(SyntaxKind.ObjectKeyword))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(Rule, pts.GetLocation(), "object"));
+            }
+            else if (context.Node is IdentifierNameSyntax ins && ins.Identifier.Text == "dynamic")
+            {
+                context.ReportDiagnostic(Diagnostic.Create(Rule, ins.GetLocation(), "dynamic"));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Code fix provider for <see cref="StrongTypingAnalyzer"/>.
+    /// </summary>
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(StrongTypingCodeFixProvider))]
+    public sealed class StrongTypingCodeFixProvider : CodeFixProvider
+    {
+        /// <inheritdoc />
+        public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(StrongTypingAnalyzer.DiagnosticId);
+
+        /// <inheritdoc />
+        public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+        /// <inheritdoc />
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+            if (root is null)
+            {
+                return;
+            }
+
+            foreach (var diagnostic in context.Diagnostics)
+            {
+                var node = root.FindNode(diagnostic.Location.SourceSpan);
+                if (node is IdentifierNameSyntax or PredefinedTypeSyntax)
+                {
+                    context.RegisterCodeFix(
+                        CodeAction.Create(
+                            "Replace with object",
+                            ct => ReplaceWithObjectAsync(context.Document, node, ct),
+                            equivalenceKey: "ReplaceWithObject"),
+                        diagnostic);
+                }
+            }
+        }
+
+        private static async Task<Document> ReplaceWithObjectAsync(Document document, SyntaxNode node, CancellationToken cancellationToken)
+        {
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            if (root is null)
+            {
+                return document;
+            }
+
+            var objectType = SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.ObjectKeyword));
+            var newRoot = root.ReplaceNode(node, objectType.WithTriviaFrom(node));
+            return document.WithSyntaxRoot(newRoot);
+        }
+    }
+}

--- a/src/CodingStandards.Analyzers/CodingStandards.Analyzers/Analyzers/Rules/ThinStartupAnalyzer.cs
+++ b/src/CodingStandards.Analyzers/CodingStandards.Analyzers/Analyzers/Rules/ThinStartupAnalyzer.cs
@@ -1,0 +1,47 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace CodingStandards.Analyzers.Rules
+{
+    /// <summary>
+    /// Enforces short Program/Startup files.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class ThinStartupAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "CSAD0014";
+        private static readonly DiagnosticDescriptor Rule = new(
+            DiagnosticId,
+            "Keep Program/Startup thin",
+            "Program or Startup file should not exceed 60 lines",
+            "Design",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        /// <inheritdoc />
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        /// <inheritdoc />
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.RegisterSyntaxTreeAction(AnalyzeTree);
+        }
+
+        private static void AnalyzeTree(SyntaxTreeAnalysisContext context)
+        {
+            var path = context.Tree.FilePath ?? string.Empty;
+            if (path.EndsWith("Program.cs") || path.EndsWith("Startup.cs"))
+            {
+                var lines = context.Tree.GetText().Lines.Count;
+                if (lines > 60)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(Rule, Location.Create(context.Tree, new TextSpan(0, 0))));
+                }
+            }
+        }
+    }
+}

--- a/src/CodingStandards.Analyzers/CodingStandards.Analyzers/Analyzers/Rules/UseRecordForDtoAnalyzer.cs
+++ b/src/CodingStandards.Analyzers/CodingStandards.Analyzers/Analyzers/Rules/UseRecordForDtoAnalyzer.cs
@@ -1,0 +1,104 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CodeActions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CodingStandards.Analyzers.Rules
+{
+    /// <summary>
+    /// Favors record types for DTOs.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class UseRecordForDtoAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "CSAD0007";
+        private static readonly DiagnosticDescriptor Rule = new(
+            DiagnosticId,
+            "Use record for DTO",
+            "DTO '{0}' should be declared as a record",
+            "Design",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        /// <inheritdoc />
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        /// <inheritdoc />
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.RegisterSyntaxNodeAction(AnalyzeClass, SyntaxKind.ClassDeclaration);
+        }
+
+        private static void AnalyzeClass(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is ClassDeclarationSyntax cls && cls.Identifier.Text.EndsWith("Dto"))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(Rule, cls.Identifier.GetLocation(), cls.Identifier.Text));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Code fix provider for <see cref="UseRecordForDtoAnalyzer"/>.
+    /// </summary>
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(UseRecordForDtoCodeFixProvider))]
+    public sealed class UseRecordForDtoCodeFixProvider : CodeFixProvider
+    {
+        /// <inheritdoc />
+        public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(UseRecordForDtoAnalyzer.DiagnosticId);
+
+        /// <inheritdoc />
+        public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+        /// <inheritdoc />
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+            if (root is null)
+            {
+                return;
+            }
+            foreach (var diagnostic in context.Diagnostics)
+            {
+                var node = root.FindNode(diagnostic.Location.SourceSpan);
+                if (node is ClassDeclarationSyntax cls)
+                {
+                    context.RegisterCodeFix(
+                        CodeAction.Create(
+                            "Convert to record",
+                            ct => ConvertToRecordAsync(context.Document, cls, ct),
+                            equivalenceKey: "ConvertToRecord"),
+                        diagnostic);
+                }
+            }
+        }
+
+        private static async Task<Document> ConvertToRecordAsync(Document document, ClassDeclarationSyntax cls, CancellationToken ct)
+        {
+            var recordDecl = SyntaxFactory.RecordDeclaration(
+                attributeLists: cls.AttributeLists,
+                modifiers: cls.Modifiers,
+                keyword: SyntaxFactory.Token(SyntaxKind.RecordKeyword),
+                identifier: cls.Identifier,
+                typeParameterList: cls.TypeParameterList,
+                parameterList: null,
+                baseList: cls.BaseList,
+                constraintClauses: cls.ConstraintClauses,
+                openBraceToken: cls.OpenBraceToken,
+                members: cls.Members,
+                closeBraceToken: cls.CloseBraceToken,
+                semicolonToken: cls.SemicolonToken);
+
+            var root = await document.GetSyntaxRootAsync(ct).ConfigureAwait(false);
+            var newRoot = root!.ReplaceNode(cls, recordDecl);
+            return document.WithSyntaxRoot(newRoot);
+        }
+    }
+}

--- a/src/CodingStandards.Analyzers/CodingStandards.Analyzers/Class1.cs
+++ b/src/CodingStandards.Analyzers/CodingStandards.Analyzers/Class1.cs
@@ -1,0 +1,5 @@
+namespace CodingStandards.Analyzers;
+
+public class Class1
+{
+}

--- a/src/CodingStandards.Analyzers/CodingStandards.Analyzers/CodingStandards.Analyzers.csproj
+++ b/src/CodingStandards.Analyzers/CodingStandards.Analyzers/CodingStandards.Analyzers.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <NoWarn>RS2008;RS1036;SA0001;SA1200;SA1208;SA1210;SA1402;SA1633;SA1513</NoWarn>
+    <PackageId>CodingStandards.Analyzers</PackageId>
+    <Version>1.0.0</Version>
+    <Authors>Example</Authors>
+    <Description>Custom analyzers enforcing coding standards.</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryUrl>https://example.com</RepositoryUrl>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="all" />
+  </ItemGroup>
+</Project>

--- a/stylecop.json
+++ b/stylecop.json
@@ -1,0 +1,8 @@
+{
+  "settings": {
+    "documentationRules": {
+      "companyName": "Example",
+      "xmlHeader": false
+    }
+  }
+}

--- a/test/CodingStandards.Analyzers.Tests/Analyzers/Rules/AsyncAwaitAnalyzerTests.cs
+++ b/test/CodingStandards.Analyzers.Tests/Analyzers/Rules/AsyncAwaitAnalyzerTests.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+using CodingStandards.Analyzers.Rules;
+using Xunit;
+using VerifyCS = CodingStandards.Analyzers.Tests.CSharpVerifier<CodingStandards.Analyzers.Rules.AsyncAwaitAnalyzer, Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+
+namespace CodingStandards.Analyzers.Tests.Analyzers.Rules
+{
+    public class AsyncAwaitAnalyzerTests
+    {
+        [Fact]
+        public async Task ReportsDiagnosticAsync()
+        {
+            var testCode = "using System.Threading.Tasks; class C { void M() { Task.CompletedTask.Wait(); } }";
+            var expected = VerifyCS.Diagnostic(AsyncAwaitAnalyzer.DiagnosticId).WithSpan(1, 71, 1, 75);
+            await new VerifyCS.Test
+            {
+                TestCode = testCode,
+                ExpectedDiagnostics = { expected }
+            }.RunAsync();
+        }
+    }
+}

--- a/test/CodingStandards.Analyzers.Tests/Analyzers/Rules/BddTestNamingAnalyzerTests.cs
+++ b/test/CodingStandards.Analyzers.Tests/Analyzers/Rules/BddTestNamingAnalyzerTests.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+using CodingStandards.Analyzers.Rules;
+using Xunit;
+using VerifyCS = CodingStandards.Analyzers.Tests.CSharpVerifier<CodingStandards.Analyzers.Rules.BddTestNamingAnalyzer, Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+
+namespace CodingStandards.Analyzers.Tests.Analyzers.Rules
+{
+    public class BddTestNamingAnalyzerTests
+    {
+        [Fact]
+        public async Task ReportsDiagnosticAsync()
+        {
+            var testCode = "using System; public class FactAttribute : Attribute {} [Fact] public class Tests { public void Test() { } }";
+            var expected = VerifyCS.Diagnostic(BddTestNamingAnalyzer.DiagnosticId).WithArguments("Test").WithSpan(1, 97, 1, 101);
+            await new VerifyCS.Test
+            {
+                TestCode = testCode,
+                ExpectedDiagnostics = { expected }
+            }.RunAsync();
+        }
+    }
+}

--- a/test/CodingStandards.Analyzers.Tests/Analyzers/Rules/BusinessLogicServiceAnalyzerTests.cs
+++ b/test/CodingStandards.Analyzers.Tests/Analyzers/Rules/BusinessLogicServiceAnalyzerTests.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+using CodingStandards.Analyzers.Rules;
+using Xunit;
+using VerifyCS = CodingStandards.Analyzers.Tests.CSharpVerifier<CodingStandards.Analyzers.Rules.BusinessLogicServiceAnalyzer, Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+
+namespace CodingStandards.Analyzers.Tests.Analyzers.Rules
+{
+    public class BusinessLogicServiceAnalyzerTests
+    {
+        [Fact]
+        public async Task ReportsDiagnosticAsync()
+        {
+            var testCode = "public class HomeController { void Index() { int x=0; x++; } }";
+            var expected = VerifyCS.Diagnostic(BusinessLogicServiceAnalyzer.DiagnosticId).WithArguments("Index").WithSpan(1, 36, 1, 41);
+            await new VerifyCS.Test
+            {
+                TestCode = testCode,
+                ExpectedDiagnostics = { expected }
+            }.RunAsync();
+        }
+    }
+}

--- a/test/CodingStandards.Analyzers.Tests/Analyzers/Rules/ConstructorInjectionAnalyzerTests.cs
+++ b/test/CodingStandards.Analyzers.Tests/Analyzers/Rules/ConstructorInjectionAnalyzerTests.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+using CodingStandards.Analyzers.Rules;
+using Xunit;
+using VerifyCS = CodingStandards.Analyzers.Tests.CSharpVerifier<CodingStandards.Analyzers.Rules.ConstructorInjectionAnalyzer, Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+
+namespace CodingStandards.Analyzers.Tests.Analyzers.Rules
+{
+    public class ConstructorInjectionAnalyzerTests
+    {
+        [Fact]
+        public async Task ReportsDiagnosticAsync()
+        {
+            var testCode = "public interface IService {} public class C { public IService S { get; set; } }";
+            var expected = VerifyCS.Diagnostic(ConstructorInjectionAnalyzer.DiagnosticId).WithSpan(1, 47, 1, 78);
+            await new VerifyCS.Test
+            {
+                TestCode = testCode,
+                ExpectedDiagnostics = { expected }
+            }.RunAsync();
+        }
+    }
+}

--- a/test/CodingStandards.Analyzers.Tests/Analyzers/Rules/DefaultInternalAnalyzerTests.cs
+++ b/test/CodingStandards.Analyzers.Tests/Analyzers/Rules/DefaultInternalAnalyzerTests.cs
@@ -1,0 +1,23 @@
+using System.Threading.Tasks;
+using CodingStandards.Analyzers.Rules;
+using Xunit;
+using VerifyCS = CodingStandards.Analyzers.Tests.CSharpVerifier<CodingStandards.Analyzers.Rules.DefaultInternalAnalyzer, Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+
+namespace CodingStandards.Analyzers.Tests.Analyzers.Rules
+{
+    public class DefaultInternalAnalyzerTests
+    {
+        [Fact]
+        public async Task ReportsDiagnosticAsync()
+        {
+            var testCode = "public class Foo { public void Bar() {} }";
+            var expected1 = VerifyCS.Diagnostic(DefaultInternalAnalyzer.DiagnosticId).WithArguments("Foo").WithSpan(1, 14, 1, 17);
+            var expected2 = VerifyCS.Diagnostic(DefaultInternalAnalyzer.DiagnosticId).WithArguments("Bar").WithSpan(1, 32, 1, 35);
+            await new VerifyCS.Test
+            {
+                TestCode = testCode,
+                ExpectedDiagnostics = { expected1, expected2 }
+            }.RunAsync();
+        }
+    }
+}

--- a/test/CodingStandards.Analyzers.Tests/Analyzers/Rules/ExceptionLoggingAnalyzerTests.cs
+++ b/test/CodingStandards.Analyzers.Tests/Analyzers/Rules/ExceptionLoggingAnalyzerTests.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+using CodingStandards.Analyzers.Rules;
+using Xunit;
+using VerifyCS = CodingStandards.Analyzers.Tests.CSharpVerifier<CodingStandards.Analyzers.Rules.ExceptionLoggingAnalyzer, Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+
+namespace CodingStandards.Analyzers.Tests.Analyzers.Rules
+{
+    public class ExceptionLoggingAnalyzerTests
+    {
+        [Fact]
+        public async Task ReportsDiagnosticAsync()
+        {
+            var testCode = "class C { void M() { try { } catch { } } }";
+            var expected = VerifyCS.Diagnostic(ExceptionLoggingAnalyzer.DiagnosticId).WithSpan(1, 30, 1, 35);
+            await new VerifyCS.Test
+            {
+                TestCode = testCode,
+                ExpectedDiagnostics = { expected }
+            }.RunAsync();
+        }
+    }
+}

--- a/test/CodingStandards.Analyzers.Tests/Analyzers/Rules/FeatureFlagAnalyzerTests.cs
+++ b/test/CodingStandards.Analyzers.Tests/Analyzers/Rules/FeatureFlagAnalyzerTests.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+using CodingStandards.Analyzers.Rules;
+using Xunit;
+using VerifyCS = CodingStandards.Analyzers.Tests.CSharpVerifier<CodingStandards.Analyzers.Rules.FeatureFlagAnalyzer, Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+
+namespace CodingStandards.Analyzers.Tests.Analyzers.Rules
+{
+    public class FeatureFlagAnalyzerTests
+    {
+        [Fact]
+        public async Task ReportsDiagnosticAsync()
+        {
+            var testCode = "class C { dynamic Configuration; void M() { var flag = Configuration[\"Flag\"]; } }";
+            var expected = VerifyCS.Diagnostic(FeatureFlagAnalyzer.DiagnosticId).WithSpan(1, 56, 1, 77);
+            await new VerifyCS.Test
+            {
+                TestCode = testCode,
+                ExpectedDiagnostics = { expected }
+            }.RunAsync();
+        }
+    }
+}

--- a/test/CodingStandards.Analyzers.Tests/Analyzers/Rules/HttpClientEncapsulationAnalyzerTests.cs
+++ b/test/CodingStandards.Analyzers.Tests/Analyzers/Rules/HttpClientEncapsulationAnalyzerTests.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+using CodingStandards.Analyzers.Rules;
+using Xunit;
+using VerifyCS = CodingStandards.Analyzers.Tests.CSharpVerifier<CodingStandards.Analyzers.Rules.HttpClientEncapsulationAnalyzer, Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+
+namespace CodingStandards.Analyzers.Tests.Analyzers.Rules
+{
+    public class HttpClientEncapsulationAnalyzerTests
+    {
+        [Fact]
+        public async Task ReportsDiagnosticAsync()
+        {
+            var testCode = "class C { void M() { var c = new System.Net.Http.HttpClient(); } }";
+            var expected = VerifyCS.Diagnostic(HttpClientEncapsulationAnalyzer.DiagnosticId).WithSpan(1, 30, 1, 62);
+            await new VerifyCS.Test
+            {
+                TestCode = testCode,
+                ExpectedDiagnostics = { expected }
+            }.RunAsync();
+        }
+    }
+}

--- a/test/CodingStandards.Analyzers.Tests/Analyzers/Rules/InputValidationAnalyzerTests.cs
+++ b/test/CodingStandards.Analyzers.Tests/Analyzers/Rules/InputValidationAnalyzerTests.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+using CodingStandards.Analyzers.Rules;
+using Xunit;
+using VerifyCS = CodingStandards.Analyzers.Tests.CSharpVerifier<CodingStandards.Analyzers.Rules.InputValidationAnalyzer, Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+
+namespace CodingStandards.Analyzers.Tests.Analyzers.Rules
+{
+    public class InputValidationAnalyzerTests
+    {
+        [Fact]
+        public async Task ReportsDiagnosticAsync()
+        {
+            var testCode = "public class HomeController { void Post(string name) { if(name==null){} } }";
+            var expected = VerifyCS.Diagnostic(InputValidationAnalyzer.DiagnosticId).WithSpan(1, 56, 1, 58);
+            await new VerifyCS.Test
+            {
+                TestCode = testCode,
+                ExpectedDiagnostics = { expected }
+            }.RunAsync();
+        }
+    }
+}

--- a/test/CodingStandards.Analyzers.Tests/Analyzers/Rules/InterfaceExposureAnalyzerTests.cs
+++ b/test/CodingStandards.Analyzers.Tests/Analyzers/Rules/InterfaceExposureAnalyzerTests.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+using CodingStandards.Analyzers.Rules;
+using Xunit;
+using VerifyCS = CodingStandards.Analyzers.Tests.CSharpVerifier<CodingStandards.Analyzers.Rules.InterfaceExposureAnalyzer, Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+
+namespace CodingStandards.Analyzers.Tests.Analyzers.Rules
+{
+    public class InterfaceExposureAnalyzerTests
+    {
+        [Fact]
+        public async Task ReportsDiagnosticAsync()
+        {
+            var testCode = "public class Service {}";
+            var expected = VerifyCS.Diagnostic(InterfaceExposureAnalyzer.DiagnosticId).WithArguments("Service").WithSpan(1, 14, 1, 21);
+            await new VerifyCS.Test
+            {
+                TestCode = testCode,
+                ExpectedDiagnostics = { expected }
+            }.RunAsync();
+        }
+    }
+}

--- a/test/CodingStandards.Analyzers.Tests/Analyzers/Rules/InterfaceNamespaceAnalyzerTests.cs
+++ b/test/CodingStandards.Analyzers.Tests/Analyzers/Rules/InterfaceNamespaceAnalyzerTests.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+using CodingStandards.Analyzers.Rules;
+using Xunit;
+using VerifyCS = CodingStandards.Analyzers.Tests.CSharpVerifier<CodingStandards.Analyzers.Rules.InterfaceNamespaceAnalyzer, Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+
+namespace CodingStandards.Analyzers.Tests.Analyzers.Rules
+{
+    public class InterfaceNamespaceAnalyzerTests
+    {
+        [Fact]
+        public async Task ReportsDiagnosticAsync()
+        {
+            var testCode = "namespace Services { public interface IMyService {} }";
+            var expected = VerifyCS.Diagnostic(InterfaceNamespaceAnalyzer.DiagnosticId).WithArguments("IMyService").WithSpan(1, 39, 1, 49);
+            await new VerifyCS.Test
+            {
+                TestCode = testCode,
+                ExpectedDiagnostics = { expected }
+            }.RunAsync();
+        }
+    }
+}

--- a/test/CodingStandards.Analyzers.Tests/Analyzers/Rules/NoBusinessInControllersAnalyzerTests.cs
+++ b/test/CodingStandards.Analyzers.Tests/Analyzers/Rules/NoBusinessInControllersAnalyzerTests.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+using CodingStandards.Analyzers.Rules;
+using Xunit;
+using VerifyCS = CodingStandards.Analyzers.Tests.CSharpVerifier<CodingStandards.Analyzers.Rules.NoBusinessInControllersAnalyzer, Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+
+namespace CodingStandards.Analyzers.Tests.Analyzers.Rules
+{
+    public class NoBusinessInControllersAnalyzerTests
+    {
+        [Fact]
+        public async Task ReportsDiagnosticAsync()
+        {
+            var testCode = "public class HomeController { void Index() { int x=0; x++; } }";
+            var expected = VerifyCS.Diagnostic(NoBusinessInControllersAnalyzer.DiagnosticId).WithArguments("Index").WithSpan(1, 36, 1, 41);
+            await new VerifyCS.Test
+            {
+                TestCode = testCode,
+                ExpectedDiagnostics = { expected }
+            }.RunAsync();
+        }
+    }
+}

--- a/test/CodingStandards.Analyzers.Tests/Analyzers/Rules/StrongTypingAnalyzerTests.cs
+++ b/test/CodingStandards.Analyzers.Tests/Analyzers/Rules/StrongTypingAnalyzerTests.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+using CodingStandards.Analyzers.Rules;
+using Xunit;
+using VerifyCS = CodingStandards.Analyzers.Tests.CSharpVerifier<CodingStandards.Analyzers.Rules.StrongTypingAnalyzer, CodingStandards.Analyzers.Rules.StrongTypingCodeFixProvider>;
+
+namespace CodingStandards.Analyzers.Tests.Analyzers.Rules
+{
+    public class StrongTypingAnalyzerTests
+    {
+        [Fact]
+        public async Task ReportsDiagnosticAndFixAsync()
+        {
+            var testCode = "class C { dynamic d; }";
+            var expected = VerifyCS.Diagnostic(StrongTypingAnalyzer.DiagnosticId).WithArguments("dynamic").WithSpan(1, 11, 1, 18);
+            await new VerifyCS.Test
+            {
+                TestCode = testCode,
+                ExpectedDiagnostics = { expected }
+            }.RunAsync();
+        }
+    }
+}

--- a/test/CodingStandards.Analyzers.Tests/Analyzers/Rules/ThinStartupAnalyzerTests.cs
+++ b/test/CodingStandards.Analyzers.Tests/Analyzers/Rules/ThinStartupAnalyzerTests.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+using CodingStandards.Analyzers.Rules;
+using Xunit;
+using VerifyCS = CodingStandards.Analyzers.Tests.CSharpVerifier<CodingStandards.Analyzers.Rules.ThinStartupAnalyzer, Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+
+namespace CodingStandards.Analyzers.Tests.Analyzers.Rules
+{
+    public class ThinStartupAnalyzerTests
+    {
+        [Fact]
+        public async Task ReportsDiagnosticAsync()
+        {
+            var lines = string.Join("\n", new string[61]);
+            var expected = VerifyCS.Diagnostic(ThinStartupAnalyzer.DiagnosticId).WithSpan("Program.cs", 1, 1, 1, 1);
+            await new VerifyCS.Test
+            {
+                TestState = { Sources = { ("Program.cs", lines) } },
+                ExpectedDiagnostics = { expected }
+            }.RunAsync();
+        }
+    }
+}

--- a/test/CodingStandards.Analyzers.Tests/Analyzers/Rules/UseRecordForDtoAnalyzerTests.cs
+++ b/test/CodingStandards.Analyzers.Tests/Analyzers/Rules/UseRecordForDtoAnalyzerTests.cs
@@ -1,0 +1,24 @@
+using System.Threading.Tasks;
+using CodingStandards.Analyzers.Rules;
+using Xunit;
+using VerifyCS = CodingStandards.Analyzers.Tests.CSharpVerifier<CodingStandards.Analyzers.Rules.UseRecordForDtoAnalyzer, CodingStandards.Analyzers.Rules.UseRecordForDtoCodeFixProvider>;
+
+namespace CodingStandards.Analyzers.Tests.Analyzers.Rules
+{
+    public class UseRecordForDtoAnalyzerTests
+    {
+        [Fact]
+        public async Task ReportsDiagnosticAndFixAsync()
+        {
+            var testCode = "class PersonDto {}";
+            var fixedCode = "record PersonDto {}";
+            var expected = VerifyCS.Diagnostic(UseRecordForDtoAnalyzer.DiagnosticId).WithArguments("PersonDto").WithSpan(1, 7, 1, 16);
+            await new VerifyCS.Test
+            {
+                TestCode = testCode,
+                FixedCode = fixedCode,
+                ExpectedDiagnostics = { expected }
+            }.RunAsync();
+        }
+    }
+}

--- a/test/CodingStandards.Analyzers.Tests/CodingStandards.Analyzers.Tests/CodingStandards.Analyzers.Tests.csproj
+++ b/test/CodingStandards.Analyzers.Tests/CodingStandards.Analyzers.Tests/CodingStandards.Analyzers.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\Verifier.cs" Link="Verifier.cs" />
+    <Compile Include="..\Analyzers\**\*.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\CodingStandards.Analyzers\CodingStandards.Analyzers\CodingStandards.Analyzers.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/CodingStandards.Analyzers.Tests/Verifier.cs
+++ b/test/CodingStandards.Analyzers.Tests/Verifier.cs
@@ -1,0 +1,26 @@
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+
+#pragma warning disable CS0618 // XUnitVerifier is obsolete in newer packages
+
+namespace CodingStandards.Analyzers.Tests
+{
+    public static class CSharpVerifier<TAnalyzer, TCodeFix>
+        where TAnalyzer : DiagnosticAnalyzer, new()
+        where TCodeFix : CodeFixProvider, new()
+    {
+        public class Test : CSharpCodeFixTest<TAnalyzer, TCodeFix, XUnitVerifier>
+        {
+            public Test()
+            {
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
+            }
+        }
+
+        public static DiagnosticResult Diagnostic(string diagnosticId) => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, XUnitVerifier>.Diagnostic(diagnosticId);
+    }
+}
+#pragma warning restore CS0618


### PR DESCRIPTION
## Summary
- target .NET 8 for analyzer tests
- remove skip attributes and fix expectations
- adjust test code to avoid compile errors
- suppress obsolete warnings in the verifier

## Testing
- `dotnet build CodingStandards.sln -tl:off`
- `dotnet test CodingStandards.sln --no-build`


------
https://chatgpt.com/codex/tasks/task_e_687502cffe6c83309f80f703f353563a